### PR TITLE
FEAT[BB-281]: Function to load the Authors of works in an edition

### DIFF
--- a/src/func/index.ts
+++ b/src/func/index.ts
@@ -31,4 +31,5 @@ export * as relationship from './relationship';
 export * as relationshipAttributes from './relationshipAttributes';
 export * as releaseEvent from './releaseEvent';
 export * as set from './set';
+export * as work from './work';
 export {createEntity} from './create-entity';

--- a/src/func/work.ts
+++ b/src/func/work.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2022  Shivam Awasthi
+ * Some parts adapted from bookbrainz-site
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+
+/**
+ * @param  {object} orm - the BookBrainz ORM, initialized during app setup
+ * @param  {object} relationship - the relationship object, with typeId=10 (Edition contains Work)
+ * @returns {Object} - Returns the relationship object after loading the author of the Work
+*/
+export async function loadAuthorNames(orm: any, relationship: any) {
+	const {RelationshipSet} = orm;
+	// const {entity} = res.locals;
+
+	async function getEntityWithAlias(relEntity) {
+		const redirectBbid = await orm.func.entity.recursivelyGetRedirectBBID(orm, relEntity.bbid, null);
+
+		return orm.Author.forge({bbid: redirectBbid})
+			.fetch({require: false, withRelated: ['defaultAlias']});
+	}
+
+	// Loading the relationshipSet of the Work
+	const relationshipSet = await RelationshipSet.forge({id: relationship.target.relationshipSetId})
+		.fetch({
+			require: false,
+			withRelated: [
+				'relationships.source'
+			]
+		});
+	const relationships = relationshipSet ? relationshipSet.related('relationships').toJSON() : [];
+
+	// Now trying to load the Author using the relationship with typeId=8, i.e, "Author Wrote Work"
+	relationship.target.author = relationships.filter(rel => rel.typeId === 8)[0];
+	if (relationship.target.author) {
+		const source = await getEntityWithAlias(relationship.target.author.source);
+		relationship.target.author = source.toJSON();
+	}
+
+	return relationship;
+}

--- a/src/func/work.ts
+++ b/src/func/work.ts
@@ -28,20 +28,6 @@ export async function loadAuthorNames(orm: any, workBBIDs: Array<string>) {
 		return [];
 	}
 
-	function queryBuilder(BBIDs) {
-		let query = '(';
-		if (BBIDs.length) {
-			query += `'${BBIDs[0]}'`;
-			for (let i = 1; i < BBIDs.length; i++) {
-				query += `, '${BBIDs[i]}'`;
-			}
-		}
-		query += ')';
-		return query;
-	}
-
-	const listOfBBIDs = queryBuilder(workBBIDs);
-
 	const sqlQuery = `select
 		author.bbid as authorBBID,
 		alias."name" as authorAlias,
@@ -65,7 +51,7 @@ export async function loadAuthorNames(orm: any, workBBIDs: Array<string>) {
 		where
 			work.master is true
 			and work.data_id is not null
-			and work.bbid in ${listOfBBIDs}`;
+			and work.bbid in ${`(${workBBIDs.map(bbid => `'${bbid}'`).join(', ')})`}`;
 
 	const queryResults = await orm.bookshelf.knex.raw(sqlQuery);
 	return queryResults.rows;

--- a/src/func/work.ts
+++ b/src/func/work.ts
@@ -24,6 +24,10 @@
  * @returns {Object} - Returns an array of objects containing the authorAlias, authorBBID of each work in an edition
 */
 export async function loadAuthorNames(orm: any, workBBIDs: Array<string>) {
+	if (!workBBIDs.length) {
+		return [];
+	}
+
 	function queryBuilder(BBIDs) {
 		let query = '(';
 		if (BBIDs.length) {


### PR DESCRIPTION
Moved the contents of the function ``loadWorkTableAuthors`` in this [PR](https://github.com/metabrainz/bookbrainz-site/pull/617), to ``src/func/work.ts``.

After loading all the relationships of an edition, the relationships with ``typeId=10`` (Edition contains Work), will be sent to this function. This function will then load the relationshipSet of the Work. From these, it will filter the relationship with ``typeId=8 ``(Author wrote work), to extract the author and then load its defaultAlias and add it to the object.
