### PR TITLE
feat(Author Credits): Add utility functions to Author model

### DIFF
--- a/src/func/author-credit.ts
+++ b/src/func/author-credit.ts
@@ -118,3 +118,72 @@ export function updateAuthorCredit(
 
 	return fetchOrCreateCredit(orm, transacting, sortedNewCreditNames);
 }
+
+
+/**
+ * Fetches all the Edition entities credited to an Author (with Author Credits)
+ * @param {object} bookshelf - the BookBrainz ORM, initialized during app setup
+ * @param {string} authorBBID - The target Author's BBID.
+ * @returns {Promise} The returned Promise returns the Edition BBID and default alias
+ */
+
+export async function getEditionsCreditedToAuthor(
+	bookshelf: any, authorBBID: string
+) {
+	const rawSql = ` SELECT e.bbid , alias."name" from bookbrainz.author
+	LEFT JOIN bookbrainz.author_credit_name acn on acn.author_bbid = author.bbid
+	LEFT JOIN bookbrainz.author_credit ac on ac.id = acn.author_credit_id
+	LEFT JOIN bookbrainz.edition e on e.author_credit_id = ac.id
+	LEFT JOIN bookbrainz.alias on alias.id  = e.default_alias_id
+	WHERE  author.bbid = '${authorBBID}'
+		AND author.master = true
+		AND e.master = true
+		AND e.data_id is not null
+	`;
+	let queryResult;
+	try {
+		queryResult = await bookshelf.knex.raw(rawSql);
+	}
+	catch (error) {
+		// eslint-disable-next-line no-console
+		console.error(error);
+	}
+	if (!Array.isArray(queryResult?.rows)) {
+		return [];
+	}
+	return queryResult.rows;
+}
+
+/**
+ * Fetches all the Edition Group entities credited to an Author (with Author Credits)
+ * @param {object} bookshelf - the BookBrainz ORM, initialized during app setup
+ * @param {string} authorBBID - The target Author's BBID.
+ * @returns {Promise} The returned Promise returns the Edition Group BBID and default alias
+ */
+
+export async function getEditionGroupsCreditedToAuthor(
+	bookshelf: any, authorBBID: string
+) {
+	const rawSql = ` SELECT eg.bbid , alias."name" from bookbrainz.author
+	LEFT JOIN bookbrainz.author_credit_name acn on acn.author_bbid = author.bbid
+	LEFT JOIN bookbrainz.author_credit ac on ac.id = acn.author_credit_id
+	LEFT JOIN bookbrainz.edition_group eg on eg.author_credit_id = ac.id
+	LEFT JOIN bookbrainz.alias on alias.id  = eg.default_alias_id
+	WHERE  author.bbid = '${authorBBID}'
+		AND author.master = true
+		AND eg.master = true
+		AND eg.data_id is not null
+	`;
+	let queryResult;
+	try {
+		queryResult = await bookshelf.knex.raw(rawSql);
+	}
+	catch (error) {
+		// eslint-disable-next-line no-console
+		console.error(error);
+	}
+	if (!Array.isArray(queryResult?.rows)) {
+		return [];
+	}
+	return queryResult.rows;
+}

--- a/src/models/data/authorData.js
+++ b/src/models/data/authorData.js
@@ -17,6 +17,7 @@
  */
 
 import {camelToSnake, formatDate, parseDate, snakeToCamel} from '../../util';
+import {getEditionGroupsCreditedToAuthor, getEditionsCreditedToAuthor} from '../../func/author-credit';
 
 
 export default function authorData(bookshelf) {
@@ -27,11 +28,25 @@ export default function authorData(bookshelf) {
 		annotation() {
 			return this.belongsTo('Annotation', 'annotation_id');
 		},
+		authorCredits() {
+			return this.hasMany('AuthorCredit', 'author_bbid')
+				.through('AuthorCreditName', 'id', 'author_bbid', 'author_credit_id');
+		},
 		authorType() {
 			return this.belongsTo('AuthorType', 'type_id');
 		},
 		beginArea() {
 			return this.belongsTo('Area', 'begin_area_id');
+		},
+		creditedEditionGroups() {
+			// Do not use this as Model.fetch({withRelated:creditedEditions)
+			// As we cannot return a promise in withRelated
+			return getEditionGroupsCreditedToAuthor(bookshelf, this.get('bbid'));
+		},
+		creditedEditions() {
+			// Do not use this as Model.fetch({withRelated:creditedEditions)
+			// As we cannot return a promise in withRelated
+			return getEditionsCreditedToAuthor(bookshelf, this.get('bbid'));
 		},
 		disambiguation() {
 			return this.belongsTo('Disambiguation', 'disambiguation_id');

--- a/src/models/revisions/editionGroupRevision.js
+++ b/src/models/revisions/editionGroupRevision.js
@@ -27,8 +27,8 @@ export default function editionGroupRevision(bookshelf) {
 		diff(other) {
 			return diffRevisions(this, other, [
 				'annotation', 'disambiguation', 'aliasSet.aliases.language',
-				'aliasSet.defaultAlias', 'identifierSet.identifiers',
-				'relationshipSet.relationships',
+				'aliasSet.defaultAlias', 'authorCredit.names',
+				'identifierSet.identifiers', 'relationshipSet.relationships',
 				'relationshipSet.relationships.type',
 				'identifierSet.identifiers.type', 'editionGroupType',
 				'relationshipSet.relationships.attributeSet.relationshipAttributes.value',


### PR DESCRIPTION
This PR adds methods to retrieve Author Credits for an Author, as well as Editions and Edition Groups credited to an Author.

Also adds tests for the same.
I took the liberty to rearrange the tests a bit to avoid some duplication and make the test suite run faster by avoiding truncating and recreating some shared elements in the database before each test.
Instead we create the common elements (gender, editor, types…) at the start and only create/truncate the elements that change (i.e. the entities)