### PR TITLE
feat: add externalServiceOauth table and functions

### DIFF
--- a/src/func/externalServiceOauth.ts
+++ b/src/func/externalServiceOauth.ts
@@ -16,6 +16,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+import type {ExternalServiceTokenT} from './types';
+
 /**
  * Fetches the Oauth token with related data
  * @param {number} editorId - Editor's id.
@@ -27,7 +29,7 @@ export async function getOauthToken(
 	editorId: number,
 	service: string,
 	orm: Record<string, any>
-): Promise<any> {
+): Promise<ExternalServiceTokenT> {
 	const rawSql =
 		`SELECT 
 			  editor_id,
@@ -84,7 +86,7 @@ export async function saveOauthToken(
 	tokenExpiresTs: number,
 	scopes: Array<string>,
 	orm: Record<string, any>
-): Promise<any> {
+): Promise<ExternalServiceTokenT> {
 	const rawSql =
 		`INSERT INTO external_service_oauth
 			(editor_id, service, access_token, refresh_token, token_expires, scopes)
@@ -134,7 +136,7 @@ export async function updateOauthToken(
 	refreshToken: string,
 	tokenExpiresTs: number,
 	orm: Record<string, any>
-): Promise<void> {
+): Promise<ExternalServiceTokenT> {
 	const rawSql =
 		`UPDATE external_service_oauth
 			SET access_token = '${accessToken}',

--- a/src/func/externalServiceOauth.ts
+++ b/src/func/externalServiceOauth.ts
@@ -40,7 +40,7 @@ export async function getOauthToken(
 		WHERE editor_id = ${editorId} 
 		  AND service = '${service}'`;
 	const result = await orm.bookshelf.knex.raw(rawSql);
-	return result.rows;
+	return result.rows[0];
 }
 
 /**

--- a/src/func/externalServiceOauth.ts
+++ b/src/func/externalServiceOauth.ts
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2022  Ansh Goyal
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+/**
+ * Fetches the Oauth token with related data
+ * @param {number} editorId - Editor's id.
+ * @param {string} service - Name of the service.
+ * @param {object} orm - the BookBrainz ORM, initialized during app setup
+ * @returns {Promise} A Promise that resolves to the oauth token in JSON format
+ */
+export async function getOauthToken(
+	editorId: number,
+	service: string,
+	orm: Record<string, any>
+): Promise<any> {
+	const rawSql =
+		`SELECT 
+			  editor_id,
+			  service,
+			  access_token,
+			  refresh_token,
+			  token_expires::text,
+              scopes
+		 FROM external_service_oauth 
+		WHERE editor_id = ${editorId} 
+		  AND service = '${service}'`;
+	const result = await orm.bookshelf.knex.raw(rawSql);
+	return result.rows;
+}
+
+/**
+ * Deletes the Oauth token with related data from the database
+ *
+ * @param {number} editorId - Editor's id.
+ * @param {string} service - name of the service.
+ * @param {object} orm - the BookBrainz ORM, initialized during app setup
+ *
+ */
+export async function deleteOauthToken(
+	editorId: number,
+	service: string,
+	orm: Record<string, any>
+): Promise<void> {
+	const {ExternalServiceOauth} = orm;
+
+	await ExternalServiceOauth.where(
+		// eslint-disable-next-line camelcase
+		{editor_id: editorId, service}
+	).destroy();
+}
+
+/**
+ * Saves the Oauth token with related data to the database
+ *
+ * @param {number} editorId - Editor's id.
+ * @param {string} service - name of the service.
+ * @param {string} accessToken - access token.
+ * @param {string} refreshToken - refresh token.
+ * @param {number} tokenExpiresTs - token expiration timestamp.
+ * @param {string[]} scopes - scopes.
+ * @param {object} orm - the BookBrainz ORM, initialized during app setup
+ * @returns {Promise} A Promise that resolves to the oauth token in JSON format
+ */
+export async function saveOauthToken(
+	editorId: number,
+	service: string,
+	accessToken: string,
+	refreshToken: string,
+	tokenExpiresTs: number,
+	scopes: Array<string>,
+	orm: Record<string, any>
+): Promise<any> {
+	const rawSql =
+		`INSERT INTO external_service_oauth
+			(editor_id, service, access_token, refresh_token, token_expires, scopes)
+		VALUES
+			(${editorId},
+			'${service}',
+			'${accessToken}',
+			'${refreshToken}',
+			to_timestamp(${tokenExpiresTs}),
+			'{${scopes}}')
+		ON CONFLICT (editor_id, service)
+		DO UPDATE SET
+			editor_id = EXCLUDED.editor_id,
+			service = EXCLUDED.service,
+			access_token = EXCLUDED.access_token,
+			refresh_token = EXCLUDED.refresh_token,
+			token_expires = EXCLUDED.token_expires,
+			scopes = EXCLUDED.scopes
+  RETURNING
+            editor_id,
+            service,
+            access_token,
+            refresh_token,
+            token_expires::text,
+            scopes;`;
+
+	const result = await orm.bookshelf.knex.raw(rawSql);
+	return result.rows[0];
+}
+
+
+/**
+ * Updates the Oauth token with related data in the database
+ *
+ * @param {number} editorId - Editor's id.
+ * @param {string} service - name of the service.
+ * @param {string} accessToken - access token.
+ * @param {string} refreshToken - refresh token.
+ * @param {number} tokenExpiresTs - token expiration timestamp.
+ * @param {object} orm - the BookBrainz ORM, initialized during app setup
+ * @returns {Promise} A Promise that resolves to the oauth token in JSON format
+ */
+export async function updateOauthToken(
+	editorId: number,
+	service: string,
+	accessToken: string,
+	refreshToken: string,
+	tokenExpiresTs: number,
+	orm: Record<string, any>
+): Promise<void> {
+	const rawSql =
+		`UPDATE external_service_oauth
+			SET access_token = '${accessToken}',
+				refresh_token = '${refreshToken}',
+				token_expires = to_timestamp(${tokenExpiresTs})
+		  WHERE editor_id = '${editorId}'
+			AND service = '${service}'
+	  RETURNING
+                editor_id,
+                service,
+                access_token,
+                refresh_token,
+                token_expires::text,
+                scopes;`;
+
+	const result = await orm.bookshelf.knex.raw(rawSql);
+	return result.rows[0];
+}

--- a/src/func/index.ts
+++ b/src/func/index.ts
@@ -23,6 +23,7 @@ export * as authorCredit from './author-credit';
 export * as disambiguation from './disambiguation';
 export * as editor from './editor';
 export * as entity from './entity';
+export * as externalServiceOauth from './externalServiceOauth';
 export * as identifier from './identifier';
 export * as imports from './imports';
 export * as language from './language';

--- a/src/func/types.ts
+++ b/src/func/types.ts
@@ -85,3 +85,12 @@ export interface AuthorCreditNameT {
 	name: string,
 	joinPhrase: string
 }
+
+export interface ExternalServiceTokenT {
+    access_token: string, // eslint-disable-line camelcase
+    editor_id: number, // eslint-disable-line camelcase
+    refresh_token: string, // eslint-disable-line camelcase
+    token_expires: string, // eslint-disable-line camelcase
+    scopes: Array<string>,
+    service: string
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,7 @@ import editor from './models/editor';
 import editorEntityVisits from './models/editorEntityVisits';
 import editorType from './models/editorType';
 import entity from './models/entity';
+import externalServiceOauth from './models/externalServiceOauth';
 import gender from './models/gender';
 import identifier from './models/identifier';
 import identifierSet from './models/identifierSet';
@@ -147,6 +148,7 @@ export default function init(config) {
 		EditorEntityVisits: editorEntityVisits(bookshelf),
 		EditorType: editorType(bookshelf),
 		Entity: entity(bookshelf),
+		ExternalServiceOauth: externalServiceOauth(bookshelf),
 		Gender: gender(bookshelf),
 		Identifier: identifier(bookshelf),
 		IdentifierSet: identifierSet(bookshelf),

--- a/src/models/externalServiceOauth.js
+++ b/src/models/externalServiceOauth.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2022  Ansh Goyal
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+
+import {camelToSnake, snakeToCamel} from '../util';
+
+
+export default function externalServiceOauth(bookshelf) {
+	const ExternalServiceOauth = bookshelf.Model.extend({
+		editor() {
+			return this.belongsTo('Editor', 'editor_id');
+		},
+		format: camelToSnake,
+		idAttribute: 'id',
+		parse: snakeToCamel,
+		tableName: 'bookbrainz.external_service_oauth'
+	});
+
+	return bookshelf.model('ExternalServiceOauth', ExternalServiceOauth);
+}
+
+

--- a/test/func/externalServiceOauth.js
+++ b/test/func/externalServiceOauth.js
@@ -1,0 +1,208 @@
+/*
+ * Copyright (C) 2022  Ansh Goyal
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+import {
+	deleteOauthToken,
+	getOauthToken,
+	saveOauthToken,
+	updateOauthToken
+} from '../../lib/func/externalServiceOauth';
+
+
+import bookbrainzData from '../bookshelf';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import {truncateTables} from '../../lib/util';
+
+
+chai.use(chaiAsPromised);
+const {expect} = chai;
+const {
+	Editor, EditorType, ExternalServiceOauth, bookshelf
+} = bookbrainzData;
+
+const editorTypeAttribs = {
+	id: 1,
+	label: 'test_type'
+};
+
+const editorAttribs = {
+	id: 1,
+	name: 'ben',
+	typeId: 1
+};
+
+const externalServiceOauthAttribs = {
+	accessToken: 'test access token',
+	editorId: 1,
+	id: 1,
+	refreshToken: 'test refresh token',
+	scopes: ['test scope'],
+	service: 'critiquebrainz',
+	tokenExpires: new Date()
+};
+
+describe('saveOauthToken', () => {
+	beforeEach(
+		async () => {
+			await new EditorType(editorTypeAttribs)
+				.save(null, {method: 'insert'});
+			await new Editor(editorAttribs)
+				.save(null, {method: 'insert'});
+		}
+	);
+
+	afterEach(function truncate() {
+		this.timeout(0); // eslint-disable-line @typescript-eslint/no-invalid-this
+
+		return truncateTables(bookshelf, [
+			'bookbrainz.external_service_oauth',
+			'bookbrainz.editor',
+			'bookbrainz.editor_type'
+		]);
+	});
+
+	it('should save oauth token and return the saved token', async () => {
+		const oauthToken = await saveOauthToken(
+			editorAttribs.id,
+			'critiquebrainz',
+			'test access token',
+			'test refresh token',
+			new Date().getTime(),
+			['test scope'],
+			bookbrainzData
+		);
+
+		return expect(oauthToken).to.have.all.keys([
+			'access_token', 'editor_id', 'refresh_token', 'scopes', 'service', 'token_expires'
+		]);
+	});
+});
+
+describe('getOauthToken', () => {
+	beforeEach(
+		async () => {
+			await new EditorType(editorTypeAttribs)
+				.save(null, {method: 'insert'});
+			await new Editor(editorAttribs)
+				.save(null, {method: 'insert'});
+			await new ExternalServiceOauth(externalServiceOauthAttribs)
+				.save(null, {method: 'insert'});
+		}
+	);
+	afterEach(function truncate() {
+		this.timeout(0); // eslint-disable-line @typescript-eslint/no-invalid-this
+
+		return truncateTables(bookshelf, [
+			// 'bookbrainz.external_service_oauth',
+			'bookbrainz.editor',
+			'bookbrainz.editor_type'
+		]);
+	});
+	it('should return oauth token', async () => {
+		const oauthToken = await getOauthToken(
+			editorAttribs.id,
+			'critiquebrainz',
+			bookbrainzData
+		);
+
+		expect(oauthToken).to.have.all.keys([
+			'access_token', 'editor_id', 'refresh_token', 'scopes', 'service', 'token_expires'
+		]);
+		expect(oauthToken.access_token).to.equal(externalServiceOauthAttribs.accessToken);
+		expect(oauthToken.editor_id).to.equal(editorAttribs.id);
+		expect(oauthToken.refresh_token).to.equal(externalServiceOauthAttribs.refreshToken);
+	});
+});
+
+
+describe('updateOauthToken', () => {
+	beforeEach(
+		async () => {
+			await new EditorType(editorTypeAttribs)
+				.save(null, {method: 'insert'});
+			await new Editor(editorAttribs)
+				.save(null, {method: 'insert'});
+			await new ExternalServiceOauth(externalServiceOauthAttribs)
+				.save(null, {method: 'insert'});
+		}
+	);
+	afterEach(function truncate() {
+		this.timeout(0); // eslint-disable-line @typescript-eslint/no-invalid-this
+
+		return truncateTables(bookshelf, [
+			'bookbrainz.external_service_oauth',
+			'bookbrainz.editor',
+			'bookbrainz.editor_type'
+		]);
+	});
+	it('should update oauth token', async () => {
+		const oauthToken = await updateOauthToken(
+			editorAttribs.id,
+			'critiquebrainz',
+			'new access token',
+			'new refresh token',
+			new Date().getTime(),
+			bookbrainzData
+		);
+
+		expect(oauthToken).to.have.all.keys([
+			'access_token', 'editor_id', 'refresh_token', 'scopes', 'service', 'token_expires'
+		]);
+		expect(oauthToken.access_token).to.equal('new access token');
+		expect(oauthToken.refresh_token).to.equal('new refresh token');
+	});
+});
+
+describe('deleteOauthToken', () => {
+	beforeEach(
+		async () => {
+			await new EditorType(editorTypeAttribs)
+				.save(null, {method: 'insert'});
+			await new Editor(editorAttribs)
+				.save(null, {method: 'insert'});
+			await new ExternalServiceOauth(externalServiceOauthAttribs)
+				.save(null, {method: 'insert'});
+		}
+	);
+	afterEach(function truncate() {
+		this.timeout(0); // eslint-disable-line @typescript-eslint/no-invalid-this
+
+		return truncateTables(bookshelf, [
+			'bookbrainz.external_service_oauth',
+			'bookbrainz.editor',
+			'bookbrainz.editor_type'
+		]);
+	});
+	it('should delete oauth token', async () => {
+		await deleteOauthToken(
+			editorAttribs.id,
+			'critiquebrainz',
+			bookbrainzData
+		);
+
+		const oauthToken = await getOauthToken(
+			editorAttribs.id,
+			'critiquebrainz',
+			bookbrainzData
+		);
+
+		return expect(oauthToken).to.be.an('undefined');
+	});
+});
+

--- a/test/testExternalServiceOauth.js
+++ b/test/testExternalServiceOauth.js
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2022  Ansh Goyal
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+import bookbrainzData from './bookshelf';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import {truncateTables} from '../lib/util';
+
+
+chai.use(chaiAsPromised);
+const {expect} = chai;
+const {
+	Editor, EditorType, ExternalServiceOauth, bookshelf
+} = bookbrainzData;
+
+
+const editorTypeAttribs = {
+	id: 1,
+	label: 'test_type'
+};
+
+const editorAttribs = {
+	id: 1,
+	name: 'ben',
+	typeId: 1
+};
+
+const externalServiceOauthAttribs = {
+	accessToken: 'test access token',
+	editorId: 1,
+	id: 1,
+	refreshToken: 'test refresh token',
+	scopes: ['test scope'],
+	service: 'critiquebrainz',
+	tokenExpires: new Date()
+};
+
+describe('ExternalServiceOauth model', () => {
+	beforeEach(
+		() =>
+			new EditorType(editorTypeAttribs)
+				.save(null, {method: 'insert'})
+				.then(
+					() =>
+						new Editor(editorAttribs)
+							.save(null, {method: 'insert'})
+				)
+	);
+
+	afterEach(function truncate() {
+		this.timeout(0); // eslint-disable-line @typescript-eslint/no-invalid-this
+
+		return truncateTables(bookshelf, [
+			'bookbrainz.external_service_oauth',
+			'bookbrainz.editor',
+			'bookbrainz.editor_type'
+		]);
+	});
+
+
+	it('should return a JSON object with correct keys when saved', () => {
+		const externalServiceOauthPromise = new ExternalServiceOauth(externalServiceOauthAttribs)
+			.save(null, {method: 'insert'})
+			.then((model) => model.refresh())
+			.then((externalServiceOauth) => externalServiceOauth.toJSON());
+
+		return expect(externalServiceOauthPromise).to.eventually.have.all.keys([
+			'accessToken', 'editorId', 'id', 'refreshToken', 'scopes', 'service', 'tokenExpires'
+		]);
+	});
+});


### PR DESCRIPTION
This PR adds the following:
1. A model for the `external_service_oauth` table.
2. Functions for fetching, saving, updating and deleting Oauth tokens in the database.