### PR TITLE
Feat: Add editions relation in AuthorCredit model

### DIFF
--- a/src/models/authorCredit.js
+++ b/src/models/authorCredit.js
@@ -21,6 +21,9 @@ import {camelToSnake, snakeToCamelID} from '../util';
 
 export default function authorCredit(bookshelf) {
 	const AuthorCredit = bookshelf.Model.extend({
+		editions() {
+			return this.hasMany('Edition', 'author_credit_id');
+		},
 		format: camelToSnake,
 		idAttribute: 'id',
 		names() {


### PR DESCRIPTION
### Problem
<!-- What are you trying to solve? -->
To support fetching all editions related to a author credit.
reference ticket: -
[BB-288](https://tickets.metabrainz.org/browse/BB-288): List publications / editions for creators

