### PR TITLE
chore: Github workflow: fix JSDoc building action

### DIFF
--- a/.github/workflows/jsdoc-gh-pages.yml
+++ b/.github/workflows/jsdoc-gh-pages.yml
@@ -15,6 +15,9 @@ jobs:
       - name: NPM install
         uses: bahmutov/npm-install@v1
 
+      - name: Build project
+        run: yarn build
+      
       - name: Build JSDoc
         uses: andstor/jsdoc-action@v1
         with:

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -11,7 +11,7 @@
         },
         {
             "type": "npm",
-            "script": "build-js",
+            "script": "build",
             "group": "build",
             "problemMatcher": []
         }

--- a/package.json
+++ b/package.json
@@ -4,16 +4,16 @@
   "description": "A JavaScript data access module for BookBrainz",
   "main": "lib/index.js",
   "scripts": {
-    "build-js": "rimraf lib/* && babel src --out-dir lib --extensions .js,.ts && tsc",
+    "build": "rimraf lib/* && babel src --out-dir lib --extensions .js,.ts && tsc",
     "build-js-for-test": "rimraf lib/* && babel src --out-dir lib --source-maps inline --extensions .js,.ts",
     "lint": "eslint .",
     "lint-errors": "eslint --quiet .",
-    "prepublishOnly": "yarn build-js",
+    "prepublishOnly": "yarn build",
     "test": "yarn build-js-for-test && yarn lint-errors && mocha",
     "test-with-report": "mocha --reporter json --reporter-option output=coverage/test-results.json",
     "test-ci": "yarn build-js-for-test && yarn lint-errors && yarn test-with-report",
     "dupreport": "jsinspect src/ || true",
-    "nodemon": "nodemon --watch './src/' --exec 'yarn build-js'"
+    "nodemon": "nodemon --watch './src/' --exec 'yarn build'"
   },
   "files": [
     "lib/**/*"


### PR DESCRIPTION
I broke the JSDoc workflow with #297, fixing it now by adding the step to build the project's JS before running the JSDoc build