### PR TITLE
fix: correctly import the `Knex.Transaction` type

### DIFF
--- a/src/func/types.ts
+++ b/src/func/types.ts
@@ -17,10 +17,10 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import type {Transaction as _Transaction} from 'knex';
+import type {Knex} from 'knex';
 
 
-export type Transaction = _Transaction<any>;
+export type Transaction = Knex.Transaction;
 
 export type EntityTypeString =
 	'Author' | 'Edition' | 'Work' | 'Publisher' | 'EditionGroup' | 'Series';


### PR DESCRIPTION
Previously this type import made the TypeScript compiler fail (using `yarn build` or `npx tsc`).
Babel was successfully compiling JS code nevertheless, so it's not a critical bug at least.

The `any` parameter of the generic type is redundant, so I dropped it.