### PR TITLE
Minimal entity typings (aliases and identifiers)

### DIFF
--- a/src/func/alias.ts
+++ b/src/func/alias.ts
@@ -21,7 +21,6 @@ import * as _ from 'lodash';
 import type {
 	FormAliasT as Alias,
 	FormAliasWithDefaultT as AliasWithDefault,
-	EntityTypeString,
 	Transaction
 } from './types';
 import {
@@ -30,6 +29,7 @@ import {
 	getRemovedItems,
 	getUnchangedItems
 } from './set';
+import type {EntityTypeString} from '../types/entity';
 import {snakeToCamel} from '../util';
 
 

--- a/src/func/entity.ts
+++ b/src/func/entity.ts
@@ -19,7 +19,7 @@
 */
 
 import * as _ from 'lodash';
-import {EntityTypeString} from './types';
+import type {EntityTypeString} from '../types/entity';
 import {parseDate} from '../util';
 
 

--- a/src/func/imports/recent-imports.ts
+++ b/src/func/imports/recent-imports.ts
@@ -17,7 +17,8 @@
  */
 
 import * as _ from 'lodash';
-import type {EntityTypeString, Transaction} from '../types';
+import type {EntityTypeString} from '../../types/entity';
+import type {Transaction} from '../types';
 import {entityTypes} from '../entity';
 import {getAliasByIds} from '../alias';
 import moment from 'moment';

--- a/src/func/relationship.ts
+++ b/src/func/relationship.ts
@@ -18,7 +18,6 @@
 
 import * as _ from 'lodash';
 import type {
-	EntityTypeString,
 	FormRelationshipT as Relationship,
 	Transaction
 } from './types';
@@ -26,6 +25,7 @@ import {
 	createNewSetWithItems,
 	removeItemsFromSet
 } from './set';
+import type {EntityTypeString} from '../types/entity';
 import {promiseProps} from '../util';
 
 

--- a/src/func/types.ts
+++ b/src/func/types.ts
@@ -22,9 +22,6 @@ import type {Transaction as _Transaction} from 'knex';
 
 export type Transaction = _Transaction<any>;
 
-export type EntityTypeString =
-	'Author' | 'Edition' | 'Work' | 'Publisher' | 'EditionGroup' | 'Series';
-
 export interface FormAliasT {
 	id: number,
 	name: string,

--- a/src/types/aliases.ts
+++ b/src/types/aliases.ts
@@ -24,7 +24,7 @@ export type AliasT = {
 	id: number,
 	name: string,
 	sortName: string,
-	languageId?: number,
+	languageId: number | null,
 	primary: boolean,
 } & LazyLoaded<{
 	language: LanguageT,
@@ -32,7 +32,7 @@ export type AliasT = {
 
 export type AliasSetT = {
 	id: number,
-	defaultAliasId?: number,
+	defaultAliasId: number | null,
 } & LazyLoaded<{
 	aliases: Array<AliasT>,
 }>;

--- a/src/types/aliases.ts
+++ b/src/types/aliases.ts
@@ -16,24 +16,23 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import {AliasSetT, AliasT} from './aliases';
-import {IdentifierSetT} from './identifiers';
+import {LanguageT} from './language';
 import {LazyLoaded} from './utils';
 
 
-export type EntityTypeString =
-	| 'Author'
-	| 'Edition'
-	| 'EditionGroup'
-	| 'Publisher'
-	| 'Series'
-	| 'Work';
-
-// TODO: incomplete
-export type EntityT = {
-	type: EntityTypeString,
+export type AliasT = {
+	id: number,
+	name: string,
+	sortName: string,
+	languageId?: number,
+	primary: boolean,
 } & LazyLoaded<{
-	aliasSet: AliasSetT,
-	defaultAlias: AliasT,
-	identifierSet: IdentifierSetT,
+	language: LanguageT,
+}>;
+
+export type AliasSetT = {
+	id: number,
+	defaultAliasId?: number,
+} & LazyLoaded<{
+	aliases: Array<AliasT>,
 }>;

--- a/src/types/entity.ts
+++ b/src/types/entity.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2023  David Kellner
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+import {IdentifierSetT} from './identifiers';
+import {LazyLoaded} from './utils';
+
+
+export type EntityTypeString =
+	| 'Author'
+	| 'Edition'
+	| 'EditionGroup'
+	| 'Publisher'
+	| 'Series'
+	| 'Work';
+
+// TODO: incomplete
+export type EntityT = {
+	type: EntityTypeString,
+} & LazyLoaded<{
+	identifierSet?: IdentifierSetT,
+}>;

--- a/src/types/identifiers.ts
+++ b/src/types/identifiers.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2023  David Kellner
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+import {EntityTypeString} from './entity';
+import {LazyLoaded} from './utils';
+
+
+export type IdentifierTypeT = {
+	id: number,
+	label: string,
+	description: string,
+	detectionRegex?: string,
+	validationRegex: string,
+	displayTemplate: string,
+	entityType: EntityTypeString,
+	parentId?: number,
+	childOrder: number,
+	deprecated: boolean,
+};
+
+export type IdentifierT = {
+	id: number,
+	typeId: number,
+	value: string,
+} & LazyLoaded<{
+	type: IdentifierTypeT,
+}>;
+
+export type IdentifierSetT = {
+	id: number,
+} & LazyLoaded<{
+	identifiers: Array<IdentifierT>,
+}>;

--- a/src/types/identifiers.ts
+++ b/src/types/identifiers.ts
@@ -24,11 +24,11 @@ export type IdentifierTypeT = {
 	id: number,
 	label: string,
 	description: string,
-	detectionRegex?: string,
+	detectionRegex: string | null,
 	validationRegex: string,
 	displayTemplate: string,
 	entityType: EntityTypeString,
-	parentId?: number,
+	parentId: number | null,
 	childOrder: number,
 	deprecated: boolean,
 };

--- a/src/types/language.ts
+++ b/src/types/language.ts
@@ -18,10 +18,10 @@
 
 export type LanguageT = {
 	id: number,
-	isoCode2t?: string,
-	isoCode2b?: string,
-	isoCode1?: string,
+	isoCode2t: string | null,
+	isoCode2b: string | null,
+	isoCode1: string | null,
 	name: string,
 	frequency: number,
-	isoCode3?: string,
+	isoCode3: string | null,
 };

--- a/src/types/language.ts
+++ b/src/types/language.ts
@@ -16,24 +16,12 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import {AliasSetT, AliasT} from './aliases';
-import {IdentifierSetT} from './identifiers';
-import {LazyLoaded} from './utils';
-
-
-export type EntityTypeString =
-	| 'Author'
-	| 'Edition'
-	| 'EditionGroup'
-	| 'Publisher'
-	| 'Series'
-	| 'Work';
-
-// TODO: incomplete
-export type EntityT = {
-	type: EntityTypeString,
-} & LazyLoaded<{
-	aliasSet: AliasSetT,
-	defaultAlias: AliasT,
-	identifierSet: IdentifierSetT,
-}>;
+export type LanguageT = {
+	id: number,
+	isoCode2t?: string,
+	isoCode2b?: string,
+	isoCode1?: string,
+	name: string,
+	frequency: number,
+	isoCode3?: string,
+};

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2023  David Kellner
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+/** Utility type to mark properties which are lazy-loaded by the ORM and might not always be present. */
+export type LazyLoaded<T> = Partial<T>;


### PR DESCRIPTION
Incomplete type definitions for entities with aliases and identifiers which were written for https://github.com/metabrainz/bookbrainz-site/pull/943 and could be used in other places too.

As long as the data models themselves are untyped, it helps to have at least some basic, separate type definitions for certain parts which are defined in a central place. They can be expanded as needed until the models have been migrated to a type-safe ORM ([BB-729](https://tickets.metabrainz.org/browse/BB-729)).
It should be trivial to integrate these provisional type definitions into the new models then.