### PR TITLE
chore: Update Node version to 18

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,7 +8,7 @@
       "@babel/env",
       {
         "targets": {
-          "node": "12.0"
+          "node": "18.0"
         }
       }
     ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           # We could also test on multiple Node versions if needed: https://github.com/actions/setup-node#matrix-testing
-          node-version: '16'
+          node-version: '18'
           # Enables caching Yarn dependencies (uses https://github.com/actions/cache under the hood)
           cache: 'yarn'
           

--- a/README.md
+++ b/README.md
@@ -27,4 +27,3 @@ The command for running the tests, following dependency installation, is the sta
 
 This will also provide style checking and coverage information.
 
-Please note, ES6 features are used within this codebase, and it has only been tested in Node 4.x. It may also work in Node 0.12.x, but not any earlier than that.

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     }
   ],
   "engines": {
-    "node": ">= 12.0"
+    "node": ">= 18.0"
   },
   "license": "GPL-2.0+",
   "bugs": {


### PR DESCRIPTION
Minimal version supported, now that Node 16 is end-of-life.

See also https://github.com/metabrainz/bookbrainz-site/pull/1016