### PR TITLE
Add 'privs' key to expected Editor model output

### DIFF
--- a/test/testEditor.js
+++ b/test/testEditor.js
@@ -103,7 +103,7 @@ describe('Editor model', () => {
 			'createdAt', 'activeAt', 'typeId', 'gender', 'genderId',
 			'areaId', 'revisionsApplied', 'revisionsReverted',
 			'totalRevisions', 'type', 'revisions', 'titleUnlockId',
-			'metabrainzUserId', 'cachedMetabrainzName'
+			'metabrainzUserId', 'cachedMetabrainzName', 'privs'
 		]);
 	});
 });


### PR DESCRIPTION
The 'privs' column was added in https://github.com/metabrainz/bookbrainz-site/pull/993 and merged into bookbrainz-site master branch in https://github.com/metabrainz/bookbrainz-site/pull/1020

This causes the testEditor test to fail with an unexpected key in the Editor model JSON.
