### PR TITLE
Repeatable imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@babel/preset-env": "^7.14.4",
     "@babel/preset-typescript": "^7.13.0",
     "@babel/register": "^7.13.16",
+    "@types/bluebird": "^3.5.41",
     "@types/lodash": "^4.14.168",
     "@types/node": "^18.11.18",
     "@types/pg": "^8.6.0",

--- a/src/func/author-credit.ts
+++ b/src/func/author-credit.ts
@@ -88,7 +88,7 @@ export async function fetchOrCreateCredit(
 		).returning(['author_bbid', 'join_phrase', 'name', 'position']);
 	/* eslint-enable camelcase */
 
-	return newCredit.refresh({transacting, withRelated: 'names'});
+	return newCredit.refresh({transacting, withRelated: ['names']});
 }
 
 export function updateAuthorCredit(

--- a/src/func/editor.ts
+++ b/src/func/editor.ts
@@ -40,6 +40,7 @@ export function incrementEditorEditCountById(
 	return new Editor({id})
 		.fetch({transacting})
 		.then((editor) => {
+			// @ts-expect-error -- Types for custom methods of Bookshelf models are lacking
 			editor.incrementEditCount();
 			return editor.save(null, {transacting});
 		});

--- a/src/func/imports/create-import.ts
+++ b/src/func/imports/create-import.ts
@@ -252,7 +252,7 @@ export function createImport(orm: ORM, importData: QueuedEntity, {
 
 		return {
 			importId,
-			status: 'created pending'
+			status: existingImport ? 'updated pending' : 'created pending'
 		};
 	});
 }

--- a/src/func/imports/create-import.ts
+++ b/src/func/imports/create-import.ts
@@ -114,18 +114,18 @@ async function updateEntityExtraDataSets(
 	return dataSets;
 }
 
-type ExistingImportAction =
+export type ExistingImportAction =
 	| 'skip'
 	| 'update pending'
 	| 'update pending and accepted';
 
-type ImportOptions = Partial<{
+export type ImportOptions = Partial<{
 
 	/** Specifies what should happen if an import with the same external identifier already exists. */
 	existingImportAction: ExistingImportAction;
 }>;
 
-type ImportStatus =
+export type ImportStatus =
 	| 'created pending'
 	| 'skipped pending'
 	| 'unchanged pending'
@@ -134,7 +134,7 @@ type ImportStatus =
 	| 'unchanged accepted'
 	| 'updated accepted';
 
-type ImportResult = {
+export type ImportResult = {
 
 	/** ID of the imported entity (numeric for now, will be a BBID in a future version). */
 	importId: number | string;

--- a/src/func/imports/create-import.ts
+++ b/src/func/imports/create-import.ts
@@ -52,11 +52,6 @@ function getImportMetadata(transacting: Transaction, externalSourceId: number, e
 function createImportDataRecord(transacting: Transaction, dataSets, importData: QueuedEntity) {
 	const {entityType} = importData;
 
-	// Safe check if entityType is one among the expected
-	if (!ENTITY_TYPES.includes(entityType)) {
-		throw new Error('Invalid entity type');
-	}
-
 	/* We omit all extra props which are not taken in as args when creating an
 	entity_data record, else it will raise error (of there being no such
 	column in the table).
@@ -79,13 +74,6 @@ function createImportDataRecord(transacting: Transaction, dataSets, importData: 
 }
 
 function createImportHeader(transacting: Transaction, record, entityType: EntityTypeString) {
-	// Safe check if entityType is one among the expected
-
-	if (!ENTITY_TYPES.includes(entityType)) {
-		throw new Error('Invalid entity type');
-	}
-
-
 	const table = `bookbrainz.${_.snakeCase(entityType)}_import_header`;
 	return transacting.insert(record).into(table).returning('import_id');
 }
@@ -127,6 +115,10 @@ type ImportOptions = Partial<{
 }>;
 
 export function createImport(orm: ORM, importData: QueuedEntity, {overwritePending = false}: ImportOptions = {}) {
+	if (!ENTITY_TYPES.includes(importData.entityType)) {
+		throw new Error('Invalid entity type');
+	}
+
 	return orm.bookshelf.transaction(async (transacting) => {
 		const {entityType} = importData;
 		const {alias, identifiers, disambiguation, source} = importData.data;

--- a/src/func/imports/create-import.ts
+++ b/src/func/imports/create-import.ts
@@ -228,6 +228,7 @@ export function createImport(orm: ORM, importData: QueuedEntity, {
 		const importMetadata: ImportMetadataT = {
 			importId,
 			importMetadata: importData.data.metadata,
+			importedAt: transacting.raw("timezone('UTC'::TEXT, now())"),
 			lastEdited: importData.lastEdited,
 			originId: importData.originId,
 			originSourceId

--- a/src/func/imports/create-import.ts
+++ b/src/func/imports/create-import.ts
@@ -180,7 +180,16 @@ export function createImport(orm: ORM, importData: QueuedEntity, {
 				// TODO: update/reuse already existing data of pending imports
 			}
 			else {
-				// TODO: create updates for already accepted entities in a later version
+				// The previously imported entity has already been accepted
+				if (existingImportAction === 'update pending') {
+					// We only want to update pending, but not accepted entities
+					return {
+						importId: existingImport.import_id,
+						status: 'skipped accepted'
+					};
+				}
+				// We also want to create updates for already accepted entities ('update pending and accepted')
+				// TODO: implement this feature in a later version and drop the following temporary return statement
 				return {
 					importId: existingImport.import_id,
 					status: 'skipped accepted'

--- a/src/func/imports/create-import.ts
+++ b/src/func/imports/create-import.ts
@@ -40,7 +40,8 @@ function createImportRecord(transacting: Transaction, data: _ImportT) {
 }
 
 function createOrUpdateImportMetadata(transacting: Transaction, record: ImportMetadataT) {
-	return transacting.upsert(camelToSnake(record)).into('bookbrainz.link_import');
+	return transacting.insert(camelToSnake(record)).into('bookbrainz.link_import')
+		.onConflict(['origin_source_id', 'origin_id']).merge();
 }
 
 function getImportMetadata(transacting: Transaction, externalSourceId: number, externalIdentifier: string) {
@@ -89,7 +90,8 @@ function createImportDataRecord(transacting: Transaction, dataSets: DataSetIds, 
 
 function createOrUpdateImportHeader(transacting: Transaction, record: ImportHeaderT, entityType: EntityTypeString) {
 	const table = `bookbrainz.${_.snakeCase(entityType)}_import_header`;
-	return transacting.upsert(camelToSnake(record)).into(table).returning('import_id');
+	return transacting.insert(camelToSnake(record)).into(table)
+		.onConflict('import_id').merge();
 }
 
 async function updateEntityExtraDataSets(

--- a/src/func/imports/create-import.ts
+++ b/src/func/imports/create-import.ts
@@ -18,7 +18,7 @@
 
 
 import {ENTITY_TYPES, type EntityTypeString} from '../../types/entity';
-import type {ImportMetadataT, _ImportT} from '../../types/imports';
+import type {ImportHeaderT, ImportMetadataT, _ImportT} from '../../types/imports';
 import type {ParsedEdition, ParsedEntity, QueuedEntity} from '../../types/parser';
 
 import type {ORM} from '../..';
@@ -73,9 +73,9 @@ function createImportDataRecord(transacting: Transaction, dataSets, importData: 
 		.returning('id');
 }
 
-function createImportHeader(transacting: Transaction, record, entityType: EntityTypeString) {
+function createImportHeader(transacting: Transaction, record: ImportHeaderT, entityType: EntityTypeString) {
 	const table = `bookbrainz.${_.snakeCase(entityType)}_import_header`;
-	return transacting.insert(record).into(table).returning('import_id');
+	return transacting.insert(camelToSnake(record)).into(table).returning('import_id');
 }
 
 type EntityDataSetIds = Partial<{
@@ -196,14 +196,10 @@ export function createImport(orm: ORM, importData: QueuedEntity, {overwritePendi
 		}
 
 		try {
-			await createImportHeader(
-				transacting,
-				[camelToSnake({dataId, importId})],
-				entityType
-			);
+			await createImportHeader(transacting, {dataId, importId}, entityType);
 		}
 		catch (err) {
-			throw new Error(`Error during importHeader creation - ${err}`);
+			throw new Error(`Failed to insert import header: ${err}`);
 		}
 
 		return importId;

--- a/src/func/imports/create-import.ts
+++ b/src/func/imports/create-import.ts
@@ -100,7 +100,8 @@ async function updateEntityExtraDataSets(
 	const dataSets: ExtraDataSetIds = {};
 
 	if (languages) {
-		dataSets.languageSetId = await updateLanguageSet(orm, transacting, null, languages);
+		const languageSet = await updateLanguageSet(orm, transacting, null, languages);
+		dataSets.languageSetId = languageSet && languageSet.get('id');
 	}
 
 	if (releaseEvents) {

--- a/src/types/imports.ts
+++ b/src/types/imports.ts
@@ -28,6 +28,11 @@ export type _ImportT = {
 
 export type _ImportWithIdT = WithId<_ImportT>;
 
+export type ImportHeaderT = {
+	importId: number;
+	dataId: number;
+};
+
 export type AdditionalImportDataT = {
 	identifiers?: IdentifierT[];
 	links: Array<{

--- a/src/types/imports.ts
+++ b/src/types/imports.ts
@@ -61,14 +61,3 @@ export type ImportMetadataT = {
 	/** JSONB */
 	importMetadata: AdditionalImportDataT;
 };
-
-/** Snake case variant of `ImportMetadataT`. */
-export type _ImportMetadataT = {
-	import_id: number;
-	origin_source_id: number;
-	origin_id: string;
-	imported_at?: any;
-	last_edited: any;
-	entity_id?: string;
-	import_metadata: any;
-};

--- a/src/types/imports.ts
+++ b/src/types/imports.ts
@@ -18,6 +18,7 @@
 
 import {EntityTypeString} from './entity';
 import {IdentifierT} from './identifiers';
+import type {Knex} from 'knex';
 import {WithId} from './utils';
 
 
@@ -55,7 +56,7 @@ export type ImportMetadataT = {
 	originId: string;
 
 	/** TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT timezone('UTC'::TEXT, now()) */
-	importedAt?: string;
+	importedAt?: Knex.Raw;
 
 	/** TIMESTAMP WITHOUT TIME ZONE */
 	lastEdited: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1171,6 +1171,11 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@types/bluebird@^3.5.41":
+  version "3.5.41"
+  resolved "https://registry.yarnpkg.com/@types/bluebird/-/bluebird-3.5.41.tgz#0ef9959efaf1de8ddd7bcef9664fc7bada60ee35"
+  integrity sha512-/OT2UoYPu2fqGNS85UYUx0Ke8Zd/vM0/Au0JqLInTprkRO0NexYe7qAUkDsjhsO3BKHI14wX/UhN5SUaoFVDUQ==
+
 "@types/json-schema@^7.0.9":
   version "7.0.11"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"


### PR DESCRIPTION
Existing imports can now be updated if they are still pending. The implementation currently only overwrites the import header to link to the freshly created entity data and leaves all the old entity data behind orphaned. (Still to be improved...)

I've also made the options parameter more flexible to already include support for creating updates for accepted entities as well (which might be added in a future version.) In addition to the import ID, the `createImport` function now also returns its status (which is used by the consumer).

Also contains a few more fixes for type errors (in currently unused code) which I somehow had not seen so far.
