### PR TITLE
part of issue BB-768 : updating the edition model function

### DIFF
--- a/src/models/entities/edition.ts
+++ b/src/models/entities/edition.ts
@@ -32,8 +32,9 @@ async function autoCreateNewEditionGroup(model, bookshelf: Bookshelf, options) {
 	const aliasSetId = model.get('aliasSetId');
 	const revisionId = model.get('revisionId');
 	const authorCreditId = model.get('authorCreditId');
+	const creditSection = model.get('creditSection');
 	const newEditionGroupBBID = await createEditionGroupForNewEdition(
-		bookshelf, options.transacting, aliasSetId, revisionId, authorCreditId
+		bookshelf, options.transacting, aliasSetId, revisionId, authorCreditId, creditSection
 	);
 	model.set('editionGroupBbid', newEditionGroupBBID);
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -243,11 +243,12 @@ export function parseDate(date: string): Array<number | null> {
  * @param {number|string} aliasSetId - The id of the new edition's alias set
  * @param {number|string} revisionId - The id of the new edition's revision
  * @param {number|string} authorCreditId - The id of the new edition's author credit
+ * @param {boolean} creditSection - The state of author credit section of the new edition
  * @returns {string} BBID of the newly created Edition Group
  */
 export async function createEditionGroupForNewEdition(
 	orm: Bookshelf, transacting: Transaction,
-	aliasSetId: number | string, revisionId: number | string, authorCreditId: number | string
+	aliasSetId: number | string, revisionId: number | string, authorCreditId: number | string, creditSection: boolean
 ): Promise<string> {
 	const Entity = orm.model('Entity');
 	const EditionGroup = orm.model('EditionGroup');
@@ -258,6 +259,7 @@ export async function createEditionGroupForNewEdition(
 		aliasSetId,
 		authorCreditId,
 		bbid,
+		creditSection,
 		revisionId
 	})
 		.save(null, {method: 'insert', transacting});


### PR DESCRIPTION

<!--
Before making a pull request, please:
1. Read the guidelines for contributing (https://github.com/bookbrainz/bookbrainz-site/blob/master/CONTRIBUTING.md)
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->BB-768
**Part of [PR 1051](https://github.com/metabrainz/bookbrainz-site/pull/1051) in bookbrainz-site repo**

### Solution
<!-- What does this PR do to fix the problem? -->

- **Part of [PR 1051](https://github.com/metabrainz/bookbrainz-site/pull/1051)**

added new creditSection argument and made some changes in `autoCreateNewEditionGroup` and `createEditionGroupForNewEdition` functions so the new auto created edition group get saved with the same state of credit section as of the edition it is created for

honestly I did not know how can i test these changes with bookbrainz-site , maybe creating my own package and copy the content with my changes from this and changing the links and package name to my npm package in package.json in bookbrainz-site, but as the changes were very small and simple this may just work 😶 

### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
edition model
