### PR TITLE
Unify entity validators

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
     "knex": "^2.4.2",
     "lodash": "^4.17.21",
     "moment": "^2.29.1",
-    "pg": "^8.6.0"
+    "pg": "^8.6.0",
+    "validator": "^13.7.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.14.3",

--- a/src/func/author.ts
+++ b/src/func/author.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2019  Kartik Pandey
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+export function labelsForAuthor(isGroup: boolean) {
+	return {
+		beginAreaLabel: isGroup ? 'Place founded' : 'Place of birth',
+		beginDateLabel: isGroup ? 'Date founded' : 'Date of birth',
+		endAreaLabel: isGroup ? 'Place of dissolution' : 'Place of death',
+		endDateLabel: isGroup ? 'Date of dissolution' : 'Date of death',
+		endedLabel: isGroup ? 'Dissolved?' : 'Died?'
+	};
+}

--- a/src/func/date.ts
+++ b/src/func/date.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2019  Nicolas Pelletier
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+import _ from 'lodash';
+
+
+export interface DateObject {
+	day: string | null;
+	month: string | null;
+	year: string | null;
+}
+
+/**
+ * Parse an ISO 8601-2004 string and return an object with separate day, month and year, if they exist.
+ * If any of the values don't exist, the default is an empty string.
+ * @function ISODateStringToObject
+ * @param {string} value - relationshipId number for initaial relationship
+ * @returns {object} a {day, month, year} object
+ */
+export function ISODateStringToObject(value: string | DateObject): DateObject {
+	if (!_.isString(value)) {
+		if (_.isPlainObject(value) && _.has(value, 'year')) {
+			return value;
+		}
+		return {day: '', month: '', year: ''};
+	}
+	const date = value ? value.split('-') : [];
+	// A leading minus sign denotes a BC date
+	// This creates an empty first array item that needs to be removed,
+	// and requires us to add the negative sign back for the year
+	if (date.length && date[0] === '') {
+		date.shift();
+		date[0] = (-parseInt(date[0], 10)).toString();
+	}
+	return {
+		day: date.length > 2 ? date[2] : '',
+		month: date.length > 1 ? date[1] : '',
+		year: date.length > 0 ? date[0] : ''
+	};
+}
+
+/**
+ * Determines wether a given date is empty or null, meaning no year month or day has been specified.
+ * Accepts a {day, month, year} object or an ISO 8601-2004 string (±YYYYYY-MM-DD)
+ * @function isNullDate
+ * @param {object|string} date - a {day, month, year} object or ISO 8601-2004 string (±YYYYYY-MM-DD)
+ * @returns {boolean} true if the date is empty/null
+ */
+export function isNullDate(date: string | DateObject): boolean {
+	const dateObject = ISODateStringToObject(date);
+	const isNullYear = _.isNil(dateObject.year) || dateObject.year === '';
+	const isNullMonth = _.isNil(dateObject.month) || dateObject.month === '';
+	const isNullDay = _.isNil(dateObject.day) || dateObject.day === '';
+	return isNullYear && isNullMonth && isNullDay;
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -18,6 +18,7 @@
  */
 
 import type Bookshelf from '@metabrainz/bookshelf';
+import {Iterable} from 'immutable';
 import type {Transaction} from './func/types';
 import _ from 'lodash';
 import {diff} from 'deep-diff';
@@ -279,4 +280,12 @@ export async function promiseProps<T>(promiseObj: Record<string, T>): Promise<Re
 		)
 	);
 	return Object.fromEntries(resolvedKeyValuePairs);
+}
+
+export function isIterable<K, V>(testVal: any): testVal is Iterable<K, V> {
+	return Iterable.isIterable(testVal);
+}
+
+export function convertMapToObject(value) {
+	return isIterable(value) ? value.toJS() : value;
 }

--- a/src/validators/author.ts
+++ b/src/validators/author.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2017  Ben Ockmore
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+
+import {dateIsBefore, get, validateDate, validatePositiveInteger} from './base';
+import {
+	validateAliases,
+	validateIdentifiers,
+	validateNameSection,
+	validateSubmissionSection
+} from './common';
+
+import _ from 'lodash';
+import type {_IdentifierType} from '../../../types';
+import {labelsForAuthor} from '../../helpers/utils';
+
+
+export function validateAuthorSectionBeginArea(value: any): boolean {
+	if (!value) {
+		return true;
+	}
+
+	return validatePositiveInteger(get(value, 'id', null), true);
+}
+
+export function validateAuthorSectionBeginDate(value: any) {
+	const {isValid, errorMessage} = validateDate(value);
+	return {errorMessage, isValid};
+}
+
+export function validateAuthorSectionEndArea(value: any): boolean {
+	if (!value) {
+		return true;
+	}
+
+	return validatePositiveInteger(get(value, 'id', null), true);
+}
+
+export function validateAuthorSectionEndDate(
+	beginValue: any, endValue: any, authorType?: string
+) {
+	const {isValid, errorMessage} = validateDate(endValue);
+	const isGroup = authorType === 'Group';
+	const {beginDateLabel, endDateLabel} = labelsForAuthor(isGroup);
+
+	if (isValid) {
+		if (dateIsBefore(beginValue, endValue)) {
+			return {errorMessage: '', isValid: true};
+		}
+
+		return {errorMessage: `${endDateLabel} must be greater than ${beginDateLabel}`, isValid: false};
+	}
+	return {errorMessage, isValid};
+}
+
+export function validateAuthorSectionEnded(value: any): boolean {
+	return _.isNull(value) || _.isBoolean(value);
+}
+
+export function validateAuthorSectionType(value: any): boolean {
+	return validatePositiveInteger(value);
+}
+
+export function validateAuthorSectionGender(value: any): boolean {
+	return validatePositiveInteger(value);
+}
+
+export function validateAuthorSection(data: any): boolean {
+	return (
+		validateAuthorSectionBeginArea(get(data, 'beginArea', null)) &&
+		validateAuthorSectionBeginDate(get(data, 'beginDate', '')).isValid &&
+		validateAuthorSectionEndArea(get(data, 'endArea', null)) &&
+		validateAuthorSectionEndDate(
+			get(data, 'beginDate', ''), get(data, 'endDate', '')
+		).isValid &&
+		validateAuthorSectionEnded(get(data, 'ended', null)) &&
+		validateAuthorSectionType(get(data, 'gender', null)) &&
+		validateAuthorSectionType(get(data, 'type', null))
+	);
+}
+
+export function validateForm(
+	formData: any, identifierTypes?: Array<_IdentifierType> | null | undefined
+): boolean {
+	const conditions = [
+		validateAliases(get(formData, 'aliasEditor', {})),
+		validateIdentifiers(
+			get(formData, 'identifierEditor', {}), identifierTypes
+		),
+		validateNameSection(get(formData, 'nameSection', {})),
+		validateAuthorSection(get(formData, 'authorSection', {})),
+		validateSubmissionSection(get(formData, 'submissionSection', {}))
+	];
+
+	return _.every(conditions);
+}

--- a/src/validators/author.ts
+++ b/src/validators/author.ts
@@ -25,9 +25,9 @@ import {
 	validateSubmissionSection
 } from './common';
 
+import type {IdentifierTypeWithIdT} from '../types/identifiers';
 import _ from 'lodash';
-import type {_IdentifierType} from '../../../types';
-import {labelsForAuthor} from '../../helpers/utils';
+import {labelsForAuthor} from '../func/author';
 
 
 export function validateAuthorSectionBeginArea(value: any): boolean {
@@ -95,7 +95,7 @@ export function validateAuthorSection(data: any): boolean {
 }
 
 export function validateForm(
-	formData: any, identifierTypes?: Array<_IdentifierType> | null | undefined
+	formData: any, identifierTypes?: Array<IdentifierTypeWithIdT> | null | undefined
 ): boolean {
 	const conditions = [
 		validateAliases(get(formData, 'aliasEditor', {})),

--- a/src/validators/author.ts
+++ b/src/validators/author.ts
@@ -18,13 +18,14 @@
  */
 
 
-import {ValidationError, dateIsBefore, get, validateDate, validatePositiveInteger} from './base';
 import {
+	type AreaStub,
 	validateAliases,
 	validateIdentifiers,
 	validateNameSection,
 	validateSubmissionSection
 } from './common';
+import {ValidationError, dateIsBefore, get, validateDate, validatePositiveInteger} from './base';
 
 import type {IdentifierTypeWithIdT} from '../types/identifiers';
 import _ from 'lodash';
@@ -104,3 +105,13 @@ export function validateAuthor(
 	validateAuthorSection(get(formData, 'authorSection', {}));
 	validateSubmissionSection(get(formData, 'submissionSection', {}));
 }
+
+export type AuthorSection = Partial<{
+	beginArea: AreaStub;
+	beginDate: string;
+	endArea: AreaStub;
+	endDate: string;
+	ended: boolean;
+	gender: number;
+	type: number;
+}>;

--- a/src/validators/author.ts
+++ b/src/validators/author.ts
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017  Ben Ockmore
+ *               2024  David Kellner
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/validators/base.ts
+++ b/src/validators/base.ts
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2017  Ben Ockmore
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+import {DateObject, ISODateStringToObject, isNullDate} from '../../helpers/utils';
+import _ from 'lodash';
+import {dateValidator} from './date';
+import {isIterable} from '../../../types';
+import validator from 'validator';
+
+
+export function get(
+	object: any,
+	path: string,
+	defaultValue: unknown | null | undefined = null
+): any {
+	if (isIterable(object)) {
+		return object.get(path, defaultValue);
+	}
+	return _.get(object, path, defaultValue);
+}
+
+export function getIn(
+	object: any,
+	paths: string[],
+	defaultValue: unknown | null | undefined = null
+): any {
+	if (isIterable(object)) {
+		return object.getIn(paths, defaultValue);
+	}
+	return _.get(object, paths, defaultValue);
+}
+
+export function absentAndRequired(value: any, required: boolean | null | undefined): boolean {
+	return Boolean(required && _.isNil(value));
+}
+
+export function nilOrString(value: any): boolean {
+	return _.isNil(value) || _.isString(value);
+}
+
+export function nilOrInteger(value: any): boolean {
+	return _.isNil(value) || _.isInteger(value);
+}
+
+export function validateOptionalString(value: any): boolean {
+	return nilOrString(value);
+}
+
+export function validateRequiredString(value: any): boolean {
+	if (!_.isString(value)) {
+		return false;
+	}
+
+	return Boolean(value);
+}
+
+export function validatePositiveInteger(
+	value: any, required = false
+): boolean {
+	if (absentAndRequired(value, required)) {
+		return false;
+	}
+
+	if (!nilOrInteger(value)) {
+		return false;
+	}
+
+	return _.isNil(value) || (_.isInteger(value) && value > 0);
+}
+
+export function validateDate(value: string | DateObject) {
+	let dateObject;
+	// We expect a string but accept both ISO date strings and {year,month,date} objects
+	if (_.isString(value)) {
+		dateObject = ISODateStringToObject(value);
+	}
+	else {
+		dateObject = value;
+	}
+	const year = _.get(dateObject, 'year', null);
+	const month = _.get(dateObject, 'month', null);
+	const day = _.get(dateObject, 'day', null);
+	const {isValid, errorMessage} = dateValidator(day, month, year);
+	return {errorMessage, isValid};
+}
+
+
+export function dateIsBefore(beginValue: string | DateObject, endValue: string | DateObject): boolean {
+	const beginDateObject = ISODateStringToObject(beginValue);
+	const endDateObject = ISODateStringToObject(endValue);
+	if (isNullDate(beginDateObject) || isNullDate(endDateObject) || !validateDate(beginDateObject).isValid ||
+		!validateDate(endDateObject).isValid) {
+		return true;
+	}
+
+	const beginYear = _.toInteger(beginDateObject.year);
+	const beginMonth = _.toInteger(beginDateObject.month);
+	const beginDay = _.toInteger(beginDateObject.day);
+
+	const endYear = _.toInteger(endDateObject.year);
+	const endMonth = _.toInteger(endDateObject.month);
+	const endDay = _.toInteger(endDateObject.day);
+
+	if (beginYear < endYear) {
+		return true;
+	}
+	else if (beginYear > endYear) {
+		return false;
+	}
+	else if (beginMonth > endMonth) {
+		return false;
+	}
+	else if (beginMonth < endMonth) {
+		return true;
+	}
+	else if (beginDay > endDay) {
+		return false;
+	}
+	else if (beginDay < endDay) {
+		return true;
+	}
+
+	return false;
+}
+
+export function validateUUID(
+	value: unknown, required = false
+): boolean {
+	if (absentAndRequired(value, required)) {
+		return false;
+	}
+
+	if (!nilOrString(value)) {
+		return false;
+	}
+
+	return !value || validator.isUUID(value);
+}

--- a/src/validators/base.ts
+++ b/src/validators/base.ts
@@ -23,6 +23,16 @@ import {isIterable} from '../util';
 import validator from 'validator';
 
 
+export class ValidationError extends Error {
+	constructor(message: string) {
+		super(message);
+		Object.defineProperty(this, 'name', {
+			enumerable: false,
+			value: 'ValidationError'
+		});
+	}
+}
+
 export function get(
 	object: any,
 	path: string,

--- a/src/validators/base.ts
+++ b/src/validators/base.ts
@@ -16,10 +16,10 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import {DateObject, ISODateStringToObject, isNullDate} from '../../helpers/utils';
+import {type DateObject, ISODateStringToObject, isNullDate} from '../func/date';
 import _ from 'lodash';
 import {dateValidator} from './date';
-import {isIterable} from '../../../types';
+import {isIterable} from '../util';
 import validator from 'validator';
 
 

--- a/src/validators/base.ts
+++ b/src/validators/base.ts
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017  Ben Ockmore
+ *               2024  David Kellner
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/validators/common.ts
+++ b/src/validators/common.ts
@@ -1,0 +1,201 @@
+/*
+ * Copyright (C) 2017  Ben Ockmore
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+import {
+	get,
+	getIn,
+	validateOptionalString,
+	validatePositiveInteger,
+	validateRequiredString,
+	validateUUID
+} from './base';
+
+import {AuthorCredit} from '../author-credit-editor/actions';
+import {Iterable} from 'immutable';
+import _ from 'lodash';
+
+
+export function validateMultiple(
+	values: any[],
+	validationFunction: (value: any, ...rest: any[]) => boolean,
+	additionalArgs?: any,
+	requiresOneOrMore?: boolean
+): boolean {
+	if (requiresOneOrMore && _.isEmpty(values)) {
+		return false;
+	}
+	let every = (object, predicate) => _.every(object, predicate);
+	if (Iterable.isIterable(values)) {
+		every = (object, predicate) => object.every(predicate);
+	}
+	else if (!_.isObject(values)) {
+		return false;
+	}
+
+	return every(values, (value) =>
+		validationFunction(value, additionalArgs));
+}
+
+export function validateAliasName(value: any): boolean {
+	return validateRequiredString(value);
+}
+
+export function validateAliasSortName(value: any): boolean {
+	return validateRequiredString(value);
+}
+
+export function validateAliasLanguage(value: any): boolean {
+	return validatePositiveInteger(value, true);
+}
+
+export function validateAliasPrimary(value: any): boolean {
+	return _.isBoolean(value);
+}
+
+export function validateAlias(value: any): boolean {
+	return (
+		validateAliasName(get(value, 'name')) &&
+		validateAliasSortName(get(value, 'sortName')) &&
+		validateAliasLanguage(get(value, 'language')) &&
+		validateAliasPrimary(get(value, 'primary'))
+	);
+}
+
+export const validateAliases = _.partial(
+	validateMultiple, _.partial.placeholder, validateAlias
+);
+
+export type IdentifierType = {
+	id: number,
+	label: string,
+	validationRegex: string
+};
+
+export function validateIdentifierValue(
+	value: any, typeId: unknown, types?: Array<IdentifierType> | null | undefined
+): boolean {
+	if (!validateRequiredString(value)) {
+		return false;
+	}
+
+	if (!types) {
+		return true;
+	}
+
+	const selectedType = _.find(types, (type) => type.id === typeId);
+
+	if (selectedType) {
+		return new RegExp(selectedType.validationRegex).test(value);
+	}
+
+	return false;
+}
+
+export function validateIdentifierType(
+	typeId: any, types?: Array<IdentifierType> | null | undefined
+): boolean {
+	if (!validatePositiveInteger(typeId, true)) {
+		return false;
+	}
+
+	if (!types) {
+		return true;
+	}
+
+	const selectedType = _.find(types, (type) => type.id === typeId);
+
+	return Boolean(selectedType);
+}
+
+export function validateIdentifier(
+	identifier: any, types?: Array<IdentifierType> | null | undefined
+): boolean {
+	const value = get(identifier, 'value');
+	const type = get(identifier, 'type');
+
+	return (
+		validateIdentifierValue(value, type, types) &&
+		validateIdentifierType(type, types)
+	);
+}
+
+type ValidateIdentifiersFunc = (identifiers: any[], types?: Array<IdentifierType> | null | undefined) => boolean;
+export const validateIdentifiers: ValidateIdentifiersFunc = _.partial(
+	validateMultiple, _.partial.placeholder,
+	validateIdentifier, _.partial.placeholder
+);
+
+export function validateNameSectionName(value: any): boolean {
+	return validateRequiredString(value);
+}
+
+export function validateNameSectionSortName(value: any): boolean {
+	return validateRequiredString(value);
+}
+
+export function validateNameSectionLanguage(value: any): boolean {
+	return validatePositiveInteger(value, true);
+}
+
+export function validateNameSectionDisambiguation(value: any): boolean {
+	return validateOptionalString(value);
+}
+
+export function validateNameSection(
+	values: any
+): boolean {
+	return (
+		validateNameSectionName(get(values, 'name', null)) &&
+		validateNameSectionSortName(get(values, 'sortName', null)) &&
+		validateNameSectionLanguage(get(values, 'language', null)) &&
+		validateNameSectionDisambiguation(get(values, 'disambiguation', null))
+	);
+}
+
+export function validateSubmissionSectionNote(value: any): boolean {
+	return validateOptionalString(value);
+}
+
+export function validateSubmissionSectionAnnotation(value: any): boolean {
+	return validateOptionalString(value);
+}
+
+export function validateSubmissionSection(
+	data: any
+): boolean {
+	return (
+		validateSubmissionSectionNote(get(data, 'note', null)) &&
+		validateSubmissionSectionAnnotation(get(data, 'annotation.content', null))
+	);
+}
+
+export function validateAuthorCreditRow(row: any): boolean {
+	return validateUUID(getIn(row, ['author', 'id'], null), true) &&
+	validateRequiredString(get(row, 'name', null)) &&
+	validateOptionalString(get(row, 'joinPhrase', null));
+}
+
+export const validateAuthorCreditSection = _.partialRight(
+	// Requires at least one Author Credit row or zero in case of optional
+	validateMultiple, _.partialRight.placeholder,
+	validateAuthorCreditRow, null, _.partialRight.placeholder
+);
+// In the merge editor we use the authorCredit directly instead of the authorCreditEditor state
+export function validateAuthorCreditSectionMerge(authorCredit:AuthorCredit) :boolean {
+	return validatePositiveInteger(get(authorCredit, 'id', null), true);
+}

--- a/src/validators/common.ts
+++ b/src/validators/common.ts
@@ -17,6 +17,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+import type {IdentifierT, IdentifierTypeWithIdT} from '../types/identifiers';
 import {
 	ValidationError,
 	get,
@@ -27,7 +28,7 @@ import {
 	validateUUID
 } from './base';
 
-import type {IdentifierTypeWithIdT} from '../types/identifiers';
+import type {AliasWithDefaultT} from '../types/aliases';
 import _ from 'lodash';
 import {isIterable} from '../util';
 
@@ -185,3 +186,40 @@ export const validateAuthorCreditSection = _.partialRight(
 export function validateAuthorCreditSectionMerge(authorCredit: any): void {
 	validatePositiveInteger(get(authorCredit, 'id', null), 'authorCredit.id', true);
 }
+
+export type NameSection = {
+	name: string;
+	sortName: string;
+	language: number;
+	default?: boolean;
+	primary: boolean;
+	disambiguation?: string;
+};
+
+// TODO: Change website and validators to use `languageId` instead of `language` to make code cleaner?
+export type AliasSection = Record<string, AliasWithDefaultT & {
+	language: number;
+}>;
+
+// TODO: Change website and validators to use `typeId` instead of `type` to make code cleaner?
+export type IdentifierSection = Record<string, IdentifierT & {
+	type: number;
+}>;
+
+/** Incomplete area type definition for validation functions. */
+export type AreaStub = {
+	id: number;
+	[x: string]: any;
+};
+
+/** Incomplete language type definition for validation functions. */
+export type LanguageStub = {
+	value: number;
+	[x: string]: any;
+};
+
+/** Incomplete entity type definition for validation functions. */
+export type EntityStub = {
+	id: string;
+	[x: string]: any;
+};

--- a/src/validators/common.ts
+++ b/src/validators/common.ts
@@ -70,11 +70,19 @@ export function validateAliasPrimary(value: any): void {
 	}
 }
 
+export function validateAliasDefault(value: any): void {
+	// Property is optional, it only exists for imported entities.
+	if (!(_.isNil(value) || _.isBoolean(value))) {
+		throw new ValidationError('Value has to be a boolean, `null` or `undefined`', 'alias.default', value);
+	}
+}
+
 export function validateAlias(value: any): void {
 	validateAliasName(get(value, 'name'));
 	validateAliasSortName(get(value, 'sortName'));
 	validateAliasLanguage(get(value, 'language'));
 	validateAliasPrimary(get(value, 'primary'));
+	validateAliasDefault(get(value, 'default', null));
 }
 
 export const validateAliases = _.partial(

--- a/src/validators/common.ts
+++ b/src/validators/common.ts
@@ -214,6 +214,14 @@ export type IdentifierSection = Record<string, IdentifierT & {
 	type: number;
 }>;
 
+export type AuthorCreditRow = {
+	author: EntityStub;
+	joinPhrase?: string;
+	name: string;
+};
+
+export type AuthorCreditSection = AuthorCreditRow[];
+
 /** Incomplete area type definition for validation functions. */
 export type AreaStub = {
 	id: number;

--- a/src/validators/common.ts
+++ b/src/validators/common.ts
@@ -25,7 +25,7 @@ import {
 	validateUUID
 } from './base';
 
-import {AuthorCredit} from '../author-credit-editor/actions';
+import type {IdentifierTypeWithIdT} from '../types/identifiers';
 import {Iterable} from 'immutable';
 import _ from 'lodash';
 
@@ -39,6 +39,8 @@ export function validateMultiple(
 	if (requiresOneOrMore && _.isEmpty(values)) {
 		return false;
 	}
+
+	// eslint-disable-next-line func-style -- we have to reassign
 	let every = (object, predicate) => _.every(object, predicate);
 	if (Iterable.isIterable(values)) {
 		every = (object, predicate) => object.every(predicate);
@@ -80,14 +82,9 @@ export const validateAliases = _.partial(
 	validateMultiple, _.partial.placeholder, validateAlias
 );
 
-export type IdentifierType = {
-	id: number,
-	label: string,
-	validationRegex: string
-};
 
 export function validateIdentifierValue(
-	value: any, typeId: unknown, types?: Array<IdentifierType> | null | undefined
+	value: any, typeId: unknown, types?: Array<IdentifierTypeWithIdT> | null | undefined
 ): boolean {
 	if (!validateRequiredString(value)) {
 		return false;
@@ -107,7 +104,7 @@ export function validateIdentifierValue(
 }
 
 export function validateIdentifierType(
-	typeId: any, types?: Array<IdentifierType> | null | undefined
+	typeId: any, types?: Array<IdentifierTypeWithIdT> | null | undefined
 ): boolean {
 	if (!validatePositiveInteger(typeId, true)) {
 		return false;
@@ -123,7 +120,7 @@ export function validateIdentifierType(
 }
 
 export function validateIdentifier(
-	identifier: any, types?: Array<IdentifierType> | null | undefined
+	identifier: any, types?: Array<IdentifierTypeWithIdT> | null | undefined
 ): boolean {
 	const value = get(identifier, 'value');
 	const type = get(identifier, 'type');
@@ -134,7 +131,7 @@ export function validateIdentifier(
 	);
 }
 
-type ValidateIdentifiersFunc = (identifiers: any[], types?: Array<IdentifierType> | null | undefined) => boolean;
+type ValidateIdentifiersFunc = (identifiers: any[], types?: Array<IdentifierTypeWithIdT> | null | undefined) => boolean;
 export const validateIdentifiers: ValidateIdentifiersFunc = _.partial(
 	validateMultiple, _.partial.placeholder,
 	validateIdentifier, _.partial.placeholder
@@ -195,7 +192,8 @@ export const validateAuthorCreditSection = _.partialRight(
 	validateMultiple, _.partialRight.placeholder,
 	validateAuthorCreditRow, null, _.partialRight.placeholder
 );
+
 // In the merge editor we use the authorCredit directly instead of the authorCreditEditor state
-export function validateAuthorCreditSectionMerge(authorCredit:AuthorCredit) :boolean {
+export function validateAuthorCreditSectionMerge(authorCredit: any) :boolean {
 	return validatePositiveInteger(get(authorCredit, 'id', null), true);
 }

--- a/src/validators/common.ts
+++ b/src/validators/common.ts
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017  Ben Ockmore
+ *               2024  David Kellner
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/validators/date.js
+++ b/src/validators/date.js
@@ -1,0 +1,65 @@
+import {isNil as _isNil} from 'lodash';
+
+
+function isEmpty(value) {
+	return _isNil(value) || value === '';
+}
+
+export function dateValidator(dayObj, monthObj, yearObj) {
+	const year = Number.parseInt(yearObj, 10);
+	const month = Number.parseInt(monthObj, 10);
+	const day = Number.parseInt(dayObj, 10);
+
+	// Valid years are any integer value or, if month and day are also nil, nil
+	if (isEmpty(yearObj)) {
+		if (isEmpty(monthObj) && isEmpty(dayObj)) {
+			return {errorMessage: '', isValid: true};
+		}
+
+		return {errorMessage: 'Year must be entered if month and day are entered', isValid: false};
+	}
+	else if (!Number.isInteger(year)) {
+		return {errorMessage: 'Year is not valid', isValid: false};
+	}
+
+	// Valid months are 1 through 12 or, if day is also nil, nil
+	if (isEmpty(monthObj)) {
+		if (isEmpty(dayObj)) {
+			return {errorMessage: '', isValid: true};
+		}
+
+		return {errorMessage: 'Month must be entered if day is entered', isValid: false};
+	}
+	else if (!Number.isInteger(month)) {
+		return {errorMessage: 'Month is not valid', isValid: false};
+	}
+	else if (month < 1 || month > 12) {
+		return {errorMessage: 'Month is not valid', isValid: false};
+	}
+
+	// Valid days are dependent on the month, but nil is also valid
+	if (isEmpty(dayObj)) {
+		return {errorMessage: '', isValid: true};
+	}
+	else if (!Number.isInteger(day)) {
+		return {errorMessage: 'Day is not valid', isValid: false};
+	}
+	else if (day < 1 || day > 31) {
+		return {errorMessage: 'Day is not valid', isValid: false};
+	}
+	else if ((month === 4 || month === 6 || month === 9 || month === 11) && day === 31) {
+		return {errorMessage: 'Day is not valid for this month', isValid: false};
+	}
+	else if (month === 2) {
+		const isLeapYear = year % 100 === 0 ? year % 400 === 0 : year % 4 === 0;
+
+		if (day < 1 || day > 29) {
+			return {errorMessage: 'Day is not valid for this month', isValid: false};
+		}
+		else if (day > 29 || (day === 29 && !isLeapYear)) {
+			return {errorMessage: 'Year is not leap, invalid day', isValid: false};
+		}
+	}
+
+	return {errorMessage: '', isValid: true};
+}

--- a/src/validators/date.ts
+++ b/src/validators/date.ts
@@ -1,3 +1,4 @@
+import {ValidationError} from './base';
 import {isNil as _isNil} from 'lodash';
 
 
@@ -5,10 +6,7 @@ function isEmpty(value: any): boolean {
 	return _isNil(value) || value === '';
 }
 
-export function dateValidator(dayObj, monthObj, yearObj): {
-	errorMessage: string;
-	isValid: boolean;
-} {
+export function dateValidator(dayObj, monthObj, yearObj): void {
 	const year = Number.parseInt(yearObj, 10);
 	const month = Number.parseInt(monthObj, 10);
 	const day = Number.parseInt(dayObj, 10);
@@ -16,53 +14,44 @@ export function dateValidator(dayObj, monthObj, yearObj): {
 	// Valid years are any integer value or, if month and day are also nil, nil
 	if (isEmpty(yearObj)) {
 		if (isEmpty(monthObj) && isEmpty(dayObj)) {
-			return {errorMessage: '', isValid: true};
+			return;
 		}
 
-		return {errorMessage: 'Year must be entered if month and day are entered', isValid: false};
+		throw new ValidationError('Year must be entered if month and day are entered');
 	}
 	else if (!Number.isInteger(year)) {
-		return {errorMessage: 'Year is not valid', isValid: false};
+		throw new ValidationError('Year is not an integer');
 	}
 
 	// Valid months are 1 through 12 or, if day is also nil, nil
 	if (isEmpty(monthObj)) {
 		if (isEmpty(dayObj)) {
-			return {errorMessage: '', isValid: true};
+			return;
 		}
 
-		return {errorMessage: 'Month must be entered if day is entered', isValid: false};
+		throw new ValidationError('Month must be entered if day is entered');
 	}
-	else if (!Number.isInteger(month)) {
-		return {errorMessage: 'Month is not valid', isValid: false};
-	}
-	else if (month < 1 || month > 12) {
-		return {errorMessage: 'Month is not valid', isValid: false};
+	else if (!Number.isInteger(month) || month < 1 || month > 12) {
+		throw new ValidationError('Month is not a valid integer');
 	}
 
 	// Valid days are dependent on the month, but nil is also valid
-	if (isEmpty(dayObj)) {
-		return {errorMessage: '', isValid: true};
-	}
-	else if (!Number.isInteger(day)) {
-		return {errorMessage: 'Day is not valid', isValid: false};
-	}
-	else if (day < 1 || day > 31) {
-		return {errorMessage: 'Day is not valid', isValid: false};
-	}
-	else if ((month === 4 || month === 6 || month === 9 || month === 11) && day === 31) {
-		return {errorMessage: 'Day is not valid for this month', isValid: false};
-	}
-	else if (month === 2) {
-		const isLeapYear = year % 100 === 0 ? year % 400 === 0 : year % 4 === 0;
-
-		if (day < 1 || day > 29) {
-			return {errorMessage: 'Day is not valid for this month', isValid: false};
+	if (!isEmpty(dayObj)) {
+		if (!Number.isInteger(day) || day < 1 || day > 31) {
+			throw new ValidationError('Day is not a valid integer');
 		}
-		else if (day > 29 || (day === 29 && !isLeapYear)) {
-			return {errorMessage: 'Year is not leap, invalid day', isValid: false};
+		else if ((month === 4 || month === 6 || month === 9 || month === 11) && day === 31) {
+			throw new ValidationError('Day is not valid for this month');
+		}
+		else if (month === 2) {
+			const isLeapYear = year % 100 === 0 ? year % 400 === 0 : year % 4 === 0;
+
+			if (day > 29) {
+				throw new ValidationError('Day is not valid for this month');
+			}
+			else if (day === 29 && !isLeapYear) {
+				throw new ValidationError('Year is not leap, day is not valid for this month');
+			}
 		}
 	}
-
-	return {errorMessage: '', isValid: true};
 }

--- a/src/validators/date.ts
+++ b/src/validators/date.ts
@@ -1,11 +1,14 @@
 import {isNil as _isNil} from 'lodash';
 
 
-function isEmpty(value) {
+function isEmpty(value: any): boolean {
 	return _isNil(value) || value === '';
 }
 
-export function dateValidator(dayObj, monthObj, yearObj) {
+export function dateValidator(dayObj, monthObj, yearObj): {
+	errorMessage: string;
+	isValid: boolean;
+} {
 	const year = Number.parseInt(yearObj, 10);
 	const month = Number.parseInt(monthObj, 10);
 	const day = Number.parseInt(dayObj, 10);

--- a/src/validators/date.ts
+++ b/src/validators/date.ts
@@ -6,6 +6,7 @@ function isEmpty(value: any): boolean {
 	return _isNil(value) || value === '';
 }
 
+// eslint-disable-next-line complexity -- Date validation is complex unless we want to use a library
 export function dateValidator(dayObj, monthObj, yearObj): void {
 	const year = Number.parseInt(yearObj, 10);
 	const month = Number.parseInt(monthObj, 10);

--- a/src/validators/edition-group.ts
+++ b/src/validators/edition-group.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2017  Ben Ockmore
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+
+import {_IdentifierType, isIterable} from '../../../types';
+import {get, validatePositiveInteger} from './base';
+import {
+	validateAliases,
+	validateAuthorCreditSection,
+	validateAuthorCreditSectionMerge,
+	validateIdentifiers,
+	validateNameSection,
+	validateSubmissionSection
+} from './common';
+
+import _ from 'lodash';
+
+
+export function validateEditionGroupSectionType(value: any): boolean {
+	return validatePositiveInteger(value);
+}
+
+export function validateEditionGroupSection(data: any): boolean {
+	return validateEditionGroupSectionType(get(data, 'type', null));
+}
+
+export function validateForm(
+	formData: any, identifierTypes?: Array<_IdentifierType> | null | undefined,
+	isMerge?:boolean
+): boolean {
+	let validAuthorCredit;
+	const authorCreditEnable = isIterable(formData) ? formData.getIn(['editionGroupSection', 'authorCreditEnable'], true) :
+		get(formData, 'editionGroupSection.authorCreditEnable', true);
+	if (isMerge) {
+		validAuthorCredit = validateAuthorCreditSectionMerge(get(formData, 'authorCredit', {}));
+	}
+	else if (!authorCreditEnable) {
+		validAuthorCredit = isIterable(formData) ? formData.get('authorCreditEditor')?.size === 0 :
+			_.size(get(formData, 'authorCreditEditor', {})) === 0;
+	}
+	else {
+		validAuthorCredit = validateAuthorCreditSection(get(formData, 'authorCreditEditor', {}), authorCreditEnable);
+	}
+	const conditions = [
+		validateAliases(get(formData, 'aliasEditor', {})),
+		validateIdentifiers(
+			get(formData, 'identifierEditor', {}), identifierTypes
+		),
+		validateNameSection(get(formData, 'nameSection', {})),
+		validateEditionGroupSection(get(formData, 'editionGroupSection', {})),
+		validAuthorCredit,
+		validateSubmissionSection(get(formData, 'submissionSection', {}))
+	];
+
+	return _.every(conditions);
+}

--- a/src/validators/edition-group.ts
+++ b/src/validators/edition-group.ts
@@ -17,7 +17,6 @@
  */
 
 
-import {_IdentifierType, isIterable} from '../../../types';
 import {get, validatePositiveInteger} from './base';
 import {
 	validateAliases,
@@ -28,7 +27,9 @@ import {
 	validateSubmissionSection
 } from './common';
 
+import type {IdentifierTypeWithIdT} from '../types/identifiers';
 import _ from 'lodash';
+import {isIterable} from '../util';
 
 
 export function validateEditionGroupSectionType(value: any): boolean {
@@ -40,11 +41,12 @@ export function validateEditionGroupSection(data: any): boolean {
 }
 
 export function validateForm(
-	formData: any, identifierTypes?: Array<_IdentifierType> | null | undefined,
+	formData: any, identifierTypes?: Array<IdentifierTypeWithIdT> | null | undefined,
 	isMerge?:boolean
 ): boolean {
 	let validAuthorCredit;
-	const authorCreditEnable = isIterable(formData) ? formData.getIn(['editionGroupSection', 'authorCreditEnable'], true) :
+	const authorCreditEnable = isIterable(formData) ?
+		formData.getIn(['editionGroupSection', 'authorCreditEnable'], true) :
 		get(formData, 'editionGroupSection.authorCreditEnable', true);
 	if (isMerge) {
 		validAuthorCredit = validateAuthorCreditSectionMerge(get(formData, 'authorCredit', {}));

--- a/src/validators/edition-group.ts
+++ b/src/validators/edition-group.ts
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017  Ben Ockmore
+ *               2024  David Kellner
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/validators/edition-group.ts
+++ b/src/validators/edition-group.ts
@@ -68,3 +68,8 @@ export function validateEditionGroup(
 	validateEditionGroupSection(get(formData, 'editionGroupSection', {}));
 	validateSubmissionSection(get(formData, 'submissionSection', {}));
 }
+
+export type EditionGroupSection = {
+	authorCreditEnable?: boolean;
+	type?: number;
+};

--- a/src/validators/edition.ts
+++ b/src/validators/edition.ts
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C) 2017  Ben Ockmore
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+
+import {_IdentifierType, isIterable} from '../../../types';
+import {get, validateDate, validatePositiveInteger, validateUUID} from './base';
+import {
+	validateAliases,
+	validateAuthorCreditSection,
+	validateAuthorCreditSectionMerge,
+	validateIdentifiers,
+	validateNameSection,
+	validateSubmissionSection
+} from './common';
+
+import {Iterable} from 'immutable';
+import _ from 'lodash';
+import {convertMapToObject} from '../../helpers/utils';
+
+
+export function validateEditionSectionDepth(value: any): boolean {
+	return validatePositiveInteger(value);
+}
+
+export function validateEditionSectionFormat(value: any): boolean {
+	return validatePositiveInteger(value);
+}
+
+export function validateEditionSectionHeight(value: any): boolean {
+	return validatePositiveInteger(value);
+}
+
+export function validateEditionSectionLanguage(value: any): boolean {
+	return validatePositiveInteger(get(value, 'value', null), true);
+}
+
+export function validateEditionSectionLanguages(values: any): boolean {
+	if (!values) {
+		return true;
+	}
+
+	let every = (object, predicate) => _.every(object, predicate);
+	if (Iterable.isIterable(values)) {
+		every = (object, predicate) => object.every(predicate);
+	}
+	else if (!_.isObject(values)) {
+		return false;
+	}
+
+	return every(values, (value) => validateEditionSectionLanguage(value));
+}
+
+export function validateEditionSectionPages(value: any): boolean {
+	return validatePositiveInteger(value);
+}
+
+export function validateEditionSectionEditionGroup(value: any, editionGroupRequired: boolean | null | undefined): boolean {
+	return validateUUID(get(value, 'id', null), editionGroupRequired);
+}
+
+export function validateEditionSectionPublisher(value: any): boolean {
+	if (!value) {
+		return true;
+	}
+	const publishers = convertMapToObject(value);
+	if (!_.isPlainObject(publishers)) {
+		return false;
+	}
+	for (const pubId in publishers) {
+		if (Object.prototype.hasOwnProperty.call(publishers, pubId)) {
+			const publisher = publishers[pubId];
+			const isValid = validateUUID(get(publisher, 'id', null), true);
+			if (!isValid) {
+				return false;
+			}
+		}
+	}
+	return true;
+}
+
+export function validateEditionSectionReleaseDate(value: any) {
+	const {isValid, errorMessage} = validateDate(value);
+	return {errorMessage, isValid};
+}
+
+export function validateEditionSectionStatus(value: any): boolean {
+	return validatePositiveInteger(value);
+}
+
+export function validateEditionSectionWeight(value: any): boolean {
+	return validatePositiveInteger(value);
+}
+
+export function validateEditionSectionWidth(value: any): boolean {
+	return validatePositiveInteger(value);
+}
+
+export function validateEditionSection(data: any): boolean {
+	return (
+		validateEditionSectionDepth(get(data, 'depth', null)) &&
+		validateEditionSectionFormat(get(data, 'format', null)) &&
+		validateEditionSectionHeight(get(data, 'height', null)) &&
+		validateEditionSectionLanguages(get(data, 'languages', null)) &&
+		validateEditionSectionPages(get(data, 'pages', null)) &&
+		validateEditionSectionEditionGroup(
+			get(data, 'editionGroup', null),
+			get(data, 'editionGroupRequired', null)
+		) &&
+		validateEditionSectionPublisher(get(data, 'publisher', null)) &&
+		validateEditionSectionReleaseDate(get(data, 'releaseDate', null)).isValid &&
+		validateEditionSectionStatus(get(data, 'status', null)) &&
+		validateEditionSectionWeight(get(data, 'weight', null)) &&
+		validateEditionSectionWidth(get(data, 'width', null))
+	);
+}
+
+export function validateForm(
+	formData: any, identifierTypes?: Array<_IdentifierType> | null | undefined,
+	isMerge?:boolean
+): boolean {
+	let validAuthorCredit;
+	const authorCreditEnable = isIterable(formData) ? formData.getIn(['editionSection', 'authorCreditEnable'], true) :
+		get(formData, 'editionSection.authorCreditEnable', true);
+	if (isMerge) {
+		validAuthorCredit = validateAuthorCreditSectionMerge(get(formData, 'authorCredit', {}));
+	}
+	else if (!authorCreditEnable) {
+		validAuthorCredit = isIterable(formData) ? formData.get('authorCreditEditor')?.size === 0 :
+			_.size(get(formData, 'authorCreditEditor', {})) === 0;
+	}
+	else {
+		validAuthorCredit = validateAuthorCreditSection(get(formData, 'authorCreditEditor', {}), authorCreditEnable);
+	}
+	const conditions = [
+		validateAliases(get(formData, 'aliasEditor', {})),
+		validateIdentifiers(
+			get(formData, 'identifierEditor', {}), identifierTypes
+		),
+		validateNameSection(get(formData, 'nameSection', {})),
+		validateEditionSection(get(formData, 'editionSection', {})),
+		validAuthorCredit,
+		validateSubmissionSection(get(formData, 'submissionSection', {}))
+	];
+
+	return _.every(conditions);
+}

--- a/src/validators/edition.ts
+++ b/src/validators/edition.ts
@@ -18,9 +18,9 @@
  */
 
 
-import {ValidationError, get, validateDate, validatePositiveInteger, validateUUID} from './base';
-import {convertMapToObject, isIterable} from '../util';
 import {
+	type EntityStub,
+	type LanguageStub,
 	validateAliases,
 	validateAuthorCreditSection,
 	validateAuthorCreditSectionMerge,
@@ -29,6 +29,8 @@ import {
 	validateNameSection,
 	validateSubmissionSection
 } from './common';
+import {ValidationError, get, validateDate, validatePositiveInteger, validateUUID} from './base';
+import {convertMapToObject, isIterable} from '../util';
 
 import {IdentifierTypeWithIdT} from '../types/identifiers';
 import _ from 'lodash';
@@ -141,3 +143,18 @@ export function validateEdition(
 	validateEditionSection(get(formData, 'editionSection', {}));
 	validateSubmissionSection(get(formData, 'submissionSection', {}));
 }
+
+export type EditionSection = {
+	authorCreditEnable?: boolean;
+	depth?: number;
+	format?: number;
+	height?: number;
+	languages?: LanguageStub[];
+	pages?: number;
+	editionGroup: EntityStub;
+	publisher?: Record<string, EntityStub>;
+	releaseDate?: string;
+	status?: number;
+	weight?: number;
+	width?: number;
+};

--- a/src/validators/edition.ts
+++ b/src/validators/edition.ts
@@ -17,7 +17,7 @@
  */
 
 
-import {_IdentifierType, isIterable} from '../../../types';
+import {convertMapToObject, isIterable} from '../util';
 import {get, validateDate, validatePositiveInteger, validateUUID} from './base';
 import {
 	validateAliases,
@@ -28,9 +28,9 @@ import {
 	validateSubmissionSection
 } from './common';
 
+import {IdentifierTypeWithIdT} from '../types/identifiers';
 import {Iterable} from 'immutable';
 import _ from 'lodash';
-import {convertMapToObject} from '../../helpers/utils';
 
 
 export function validateEditionSectionDepth(value: any): boolean {
@@ -54,6 +54,7 @@ export function validateEditionSectionLanguages(values: any): boolean {
 		return true;
 	}
 
+	// eslint-disable-next-line func-style -- we have to reassign
 	let every = (object, predicate) => _.every(object, predicate);
 	if (Iterable.isIterable(values)) {
 		every = (object, predicate) => object.every(predicate);
@@ -69,7 +70,10 @@ export function validateEditionSectionPages(value: any): boolean {
 	return validatePositiveInteger(value);
 }
 
-export function validateEditionSectionEditionGroup(value: any, editionGroupRequired: boolean | null | undefined): boolean {
+export function validateEditionSectionEditionGroup(
+	value: any,
+	editionGroupRequired: boolean | null | undefined
+): boolean {
 	return validateUUID(get(value, 'id', null), editionGroupRequired);
 }
 
@@ -130,7 +134,7 @@ export function validateEditionSection(data: any): boolean {
 }
 
 export function validateForm(
-	formData: any, identifierTypes?: Array<_IdentifierType> | null | undefined,
+	formData: any, identifierTypes?: Array<IdentifierTypeWithIdT> | null | undefined,
 	isMerge?:boolean
 ): boolean {
 	let validAuthorCredit;

--- a/src/validators/edition.ts
+++ b/src/validators/edition.ts
@@ -17,149 +17,126 @@
  */
 
 
+import {ValidationError, get, validateDate, validatePositiveInteger, validateUUID} from './base';
 import {convertMapToObject, isIterable} from '../util';
-import {get, validateDate, validatePositiveInteger, validateUUID} from './base';
 import {
 	validateAliases,
 	validateAuthorCreditSection,
 	validateAuthorCreditSectionMerge,
 	validateIdentifiers,
+	validateMultiple,
 	validateNameSection,
 	validateSubmissionSection
 } from './common';
 
 import {IdentifierTypeWithIdT} from '../types/identifiers';
-import {Iterable} from 'immutable';
 import _ from 'lodash';
 
 
-export function validateEditionSectionDepth(value: any): boolean {
-	return validatePositiveInteger(value);
+export function validateEditionSectionDepth(value: any): void {
+	validatePositiveInteger(value, 'editionSection.depth');
 }
 
-export function validateEditionSectionFormat(value: any): boolean {
-	return validatePositiveInteger(value);
+export function validateEditionSectionFormat(value: any): void {
+	validatePositiveInteger(value, 'editionSection.format');
 }
 
-export function validateEditionSectionHeight(value: any): boolean {
-	return validatePositiveInteger(value);
+export function validateEditionSectionHeight(value: any): void {
+	validatePositiveInteger(value, 'editionSection.height');
 }
 
-export function validateEditionSectionLanguage(value: any): boolean {
-	return validatePositiveInteger(get(value, 'value', null), true);
+export function validateEditionSectionLanguage(value: any): void {
+	validatePositiveInteger(get(value, 'value', null), 'editionSection.language', true);
 }
 
-export function validateEditionSectionLanguages(values: any): boolean {
-	if (!values) {
-		return true;
+export function validateEditionSectionLanguages(values: any): void {
+	// TODO: Passing for nil values is inconsistent with aliases and identifiers?
+	if (values) {
+		validateMultiple(values, validateEditionSectionLanguage);
 	}
-
-	// eslint-disable-next-line func-style -- we have to reassign
-	let every = (object, predicate) => _.every(object, predicate);
-	if (Iterable.isIterable(values)) {
-		every = (object, predicate) => object.every(predicate);
-	}
-	else if (!_.isObject(values)) {
-		return false;
-	}
-
-	return every(values, (value) => validateEditionSectionLanguage(value));
 }
 
-export function validateEditionSectionPages(value: any): boolean {
-	return validatePositiveInteger(value);
+export function validateEditionSectionPages(value: any): void {
+	validatePositiveInteger(value, 'editionSection.pages');
 }
 
 export function validateEditionSectionEditionGroup(
 	value: any,
 	editionGroupRequired: boolean | null | undefined
-): boolean {
-	return validateUUID(get(value, 'id', null), editionGroupRequired);
+): void {
+	validateUUID(get(value, 'id', null), 'editionSection.editionGroup.id', editionGroupRequired);
 }
 
-export function validateEditionSectionPublisher(value: any): boolean {
+export function validateEditionSectionPublisher(value: any): void {
 	if (!value) {
-		return true;
+		return;
 	}
 	const publishers = convertMapToObject(value);
 	if (!_.isPlainObject(publishers)) {
-		return false;
+		throw new ValidationError('Value is no plain object', 'editionSection.publisher', publishers);
 	}
 	for (const pubId in publishers) {
 		if (Object.prototype.hasOwnProperty.call(publishers, pubId)) {
 			const publisher = publishers[pubId];
-			const isValid = validateUUID(get(publisher, 'id', null), true);
-			if (!isValid) {
-				return false;
-			}
+			validateUUID(get(publisher, 'id', null), 'editionSection.publisher.id', true);
 		}
 	}
-	return true;
 }
 
-export function validateEditionSectionReleaseDate(value: any) {
-	const {isValid, errorMessage} = validateDate(value);
-	return {errorMessage, isValid};
+export function validateEditionSectionReleaseDate(value: any): void {
+	validateDate(value, 'editionSection.releaseDate');
 }
 
-export function validateEditionSectionStatus(value: any): boolean {
-	return validatePositiveInteger(value);
+export function validateEditionSectionStatus(value: any): void {
+	validatePositiveInteger(value, 'editionSection.status');
 }
 
-export function validateEditionSectionWeight(value: any): boolean {
-	return validatePositiveInteger(value);
+export function validateEditionSectionWeight(value: any): void {
+	validatePositiveInteger(value, 'editionSection.weight');
 }
 
-export function validateEditionSectionWidth(value: any): boolean {
-	return validatePositiveInteger(value);
+export function validateEditionSectionWidth(value: any): void {
+	validatePositiveInteger(value, 'editionSection.width');
 }
 
-export function validateEditionSection(data: any): boolean {
-	return (
-		validateEditionSectionDepth(get(data, 'depth', null)) &&
-		validateEditionSectionFormat(get(data, 'format', null)) &&
-		validateEditionSectionHeight(get(data, 'height', null)) &&
-		validateEditionSectionLanguages(get(data, 'languages', null)) &&
-		validateEditionSectionPages(get(data, 'pages', null)) &&
-		validateEditionSectionEditionGroup(
-			get(data, 'editionGroup', null),
-			get(data, 'editionGroupRequired', null)
-		) &&
-		validateEditionSectionPublisher(get(data, 'publisher', null)) &&
-		validateEditionSectionReleaseDate(get(data, 'releaseDate', null)).isValid &&
-		validateEditionSectionStatus(get(data, 'status', null)) &&
-		validateEditionSectionWeight(get(data, 'weight', null)) &&
-		validateEditionSectionWidth(get(data, 'width', null))
-	);
+export function validateEditionSection(data: any): void {
+	validateEditionSectionDepth(get(data, 'depth', null));
+	validateEditionSectionFormat(get(data, 'format', null));
+	validateEditionSectionHeight(get(data, 'height', null));
+	validateEditionSectionLanguages(get(data, 'languages', null));
+	validateEditionSectionPages(get(data, 'pages', null));
+	validateEditionSectionEditionGroup(get(data, 'editionGroup', null), get(data, 'editionGroupRequired', null));
+	validateEditionSectionPublisher(get(data, 'publisher', null));
+	validateEditionSectionReleaseDate(get(data, 'releaseDate', null));
+	validateEditionSectionStatus(get(data, 'status', null));
+	validateEditionSectionWeight(get(data, 'weight', null));
+	validateEditionSectionWidth(get(data, 'width', null));
 }
 
-export function validateForm(
+export function validateEdition(
 	formData: any, identifierTypes?: Array<IdentifierTypeWithIdT> | null | undefined,
-	isMerge?:boolean
-): boolean {
-	let validAuthorCredit;
-	const authorCreditEnable = isIterable(formData) ? formData.getIn(['editionSection', 'authorCreditEnable'], true) :
+	isMerge?: boolean
+): void {
+	const authorCreditEnable = isIterable(formData) ?
+		formData.getIn(['editionSection', 'authorCreditEnable'], true) :
 		get(formData, 'editionSection.authorCreditEnable', true);
 	if (isMerge) {
-		validAuthorCredit = validateAuthorCreditSectionMerge(get(formData, 'authorCredit', {}));
+		validateAuthorCreditSectionMerge(get(formData, 'authorCredit', {}));
 	}
 	else if (!authorCreditEnable) {
-		validAuthorCredit = isIterable(formData) ? formData.get('authorCreditEditor')?.size === 0 :
+		const emptyAuthorCredit = isIterable(formData) ? formData.get('authorCreditEditor')?.size === 0 :
 			_.size(get(formData, 'authorCreditEditor', {})) === 0;
+		if (!emptyAuthorCredit) {
+			throw new ValidationError('Disabled author credit has to be empty', 'authorCreditEditor');
+		}
 	}
 	else {
-		validAuthorCredit = validateAuthorCreditSection(get(formData, 'authorCreditEditor', {}), authorCreditEnable);
+		validateAuthorCreditSection(get(formData, 'authorCreditEditor', {}), authorCreditEnable);
 	}
-	const conditions = [
-		validateAliases(get(formData, 'aliasEditor', {})),
-		validateIdentifiers(
-			get(formData, 'identifierEditor', {}), identifierTypes
-		),
-		validateNameSection(get(formData, 'nameSection', {})),
-		validateEditionSection(get(formData, 'editionSection', {})),
-		validAuthorCredit,
-		validateSubmissionSection(get(formData, 'submissionSection', {}))
-	];
 
-	return _.every(conditions);
+	validateAliases(get(formData, 'aliasEditor', {}));
+	validateIdentifiers(get(formData, 'identifierEditor', {}), identifierTypes);
+	validateNameSection(get(formData, 'nameSection', {}));
+	validateEditionSection(get(formData, 'editionSection', {}));
+	validateSubmissionSection(get(formData, 'submissionSection', {}));
 }

--- a/src/validators/edition.ts
+++ b/src/validators/edition.ts
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017  Ben Ockmore
+ *               2024  David Kellner
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/validators/publisher.ts
+++ b/src/validators/publisher.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2017  Ben Ockmore
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+import {dateIsBefore, get, validateDate, validatePositiveInteger} from './base';
+import {
+	validateAliases, validateIdentifiers, validateNameSection,
+	validateSubmissionSection
+} from './common';
+import _ from 'lodash';
+import type {_IdentifierType} from '../../../types';
+
+
+export function validatePublisherSectionArea(value: any): boolean {
+	if (!value) {
+		return true;
+	}
+
+	return validatePositiveInteger(get(value, 'id', null), true);
+}
+
+export function validatePublisherSectionBeginDate(value: any) {
+	const {isValid, errorMessage} = validateDate(value);
+	return {errorMessage, isValid};
+}
+
+export function validatePublisherSectionEndDate(
+	beginValue: any, endValue: any, ended: boolean
+) {
+	if (ended === false) {
+		return {errorMessage: 'Dissolved date will be ignored', isValid: true};
+	}
+	const {isValid, errorMessage} = validateDate(endValue);
+
+	if (isValid) {
+		if (dateIsBefore(beginValue, endValue)) {
+			return {errorMessage: '', isValid: true};
+		}
+		return {errorMessage: 'Dissolved Date must be greater than Founded Date', isValid: false};
+	}
+	return {errorMessage, isValid};
+}
+
+export function validatePublisherSectionEnded(value: any): boolean {
+	return _.isNull(value) || _.isBoolean(value);
+}
+
+export function validatePublisherSectionType(value: any): boolean {
+	return validatePositiveInteger(value);
+}
+
+
+export function validatePublisherSection(data: any): boolean {
+	return (
+		validatePublisherSectionArea(get(data, 'area', null)) &&
+		validatePublisherSectionBeginDate(get(data, 'beginDate', '')).isValid &&
+		validatePublisherSectionEndDate(
+			get(data, 'beginDate', ''), get(data, 'endDate', ''), get(data, 'ended', null)
+		).isValid &&
+		validatePublisherSectionEnded(get(data, 'ended', null)) &&
+		validatePublisherSectionType(get(data, 'type', null))
+	);
+}
+
+export function validateForm(
+	formData: any, identifierTypes?: Array<_IdentifierType> | null | undefined
+): boolean {
+	const conditions = [
+		validateAliases(get(formData, 'aliasEditor', {})),
+		validateIdentifiers(
+			get(formData, 'identifierEditor', {}), identifierTypes
+		),
+		validateNameSection(get(formData, 'nameSection', {})),
+		validatePublisherSection(get(formData, 'publisherSection', {})),
+		validateSubmissionSection(get(formData, 'submissionSection', {}))
+	];
+
+	return _.every(conditions);
+}

--- a/src/validators/publisher.ts
+++ b/src/validators/publisher.ts
@@ -21,8 +21,8 @@ import {
 	validateAliases, validateIdentifiers, validateNameSection,
 	validateSubmissionSection
 } from './common';
+import type {IdentifierTypeWithIdT} from '../types/identifiers';
 import _ from 'lodash';
-import type {_IdentifierType} from '../../../types';
 
 
 export function validatePublisherSectionArea(value: any): boolean {
@@ -77,7 +77,7 @@ export function validatePublisherSection(data: any): boolean {
 }
 
 export function validateForm(
-	formData: any, identifierTypes?: Array<_IdentifierType> | null | undefined
+	formData: any, identifierTypes?: Array<IdentifierTypeWithIdT> | null | undefined
 ): boolean {
 	const conditions = [
 		validateAliases(get(formData, 'aliasEditor', {})),

--- a/src/validators/publisher.ts
+++ b/src/validators/publisher.ts
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017  Ben Ockmore
+ *               2024  David Kellner
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/validators/publisher.ts
+++ b/src/validators/publisher.ts
@@ -17,11 +17,12 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import {ValidationError, dateIsBefore, get, validateDate, validatePositiveInteger} from './base';
 import {
+	type AreaStub,
 	validateAliases, validateIdentifiers, validateNameSection,
 	validateSubmissionSection
 } from './common';
+import {ValidationError, dateIsBefore, get, validateDate, validatePositiveInteger} from './base';
 import type {IdentifierTypeWithIdT} from '../types/identifiers';
 import _ from 'lodash';
 
@@ -87,3 +88,11 @@ export function validatePublisher(
 	validatePublisherSection(get(formData, 'publisherSection', {}));
 	validateSubmissionSection(get(formData, 'submissionSection', {}));
 }
+
+export type PublisherSection = Partial<{
+	area: AreaStub;
+	beginDate: string;
+	endDate: string;
+	ended: boolean;
+	type: number;
+}>;

--- a/src/validators/series.ts
+++ b/src/validators/series.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2021  Akash Gupta
+ *
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+
+import {get, validatePositiveInteger} from './base';
+import {
+	validateAliases,
+	validateIdentifiers,
+	validateNameSection,
+	validateSubmissionSection
+} from './common';
+
+import _ from 'lodash';
+import type {_IdentifierType} from '../../../types';
+
+
+export function validateSeriesSectionOrderingType(value: any): boolean {
+	return validatePositiveInteger(value, true);
+}
+
+export function validateSeriesSectionEntityType(value: any): boolean {
+	const entity = ['Author', 'Work', 'Edition', 'EditionGroup', 'Publisher'];
+	return entity.includes(value);
+}
+
+export function validateSeriesSection(data: any): boolean {
+	return (
+		validateSeriesSectionOrderingType(get(data, 'orderType', null)) &&
+		validateSeriesSectionEntityType(get(data, 'seriesType', null))
+
+	);
+}
+
+export function validateForm(
+	formData: any, identifierTypes?: Array<_IdentifierType> | null | undefined
+): boolean {
+	const conditions = [
+		validateAliases(get(formData, 'aliasEditor', {})),
+		validateIdentifiers(
+			get(formData, 'identifierEditor', {}), identifierTypes
+		),
+		validateNameSection(get(formData, 'nameSection', {})),
+		validateSeriesSection(get(formData, 'seriesSection', {})),
+		validateSubmissionSection(get(formData, 'submissionSection', {}))
+	];
+
+	return _.every(conditions);
+}

--- a/src/validators/series.ts
+++ b/src/validators/series.ts
@@ -27,6 +27,7 @@ import {
 	validateSubmissionSection
 } from './common';
 
+import type {EntityTypeString} from '../types/entity';
 import type {IdentifierTypeWithIdT} from '../types/identifiers';
 
 
@@ -59,3 +60,8 @@ export function validateSeries(
 	validateSeriesSection(get(formData, 'seriesSection', {}));
 	validateSubmissionSection(get(formData, 'submissionSection', {}));
 }
+
+export type SeriesSection = Partial<{
+	orderType: number;
+	seriesType: Exclude<EntityTypeString, 'Series'>;
+}>;

--- a/src/validators/series.ts
+++ b/src/validators/series.ts
@@ -26,8 +26,8 @@ import {
 	validateSubmissionSection
 } from './common';
 
+import type {IdentifierTypeWithIdT} from '../types/identifiers';
 import _ from 'lodash';
-import type {_IdentifierType} from '../../../types';
 
 
 export function validateSeriesSectionOrderingType(value: any): boolean {
@@ -48,7 +48,7 @@ export function validateSeriesSection(data: any): boolean {
 }
 
 export function validateForm(
-	formData: any, identifierTypes?: Array<_IdentifierType> | null | undefined
+	formData: any, identifierTypes?: Array<IdentifierTypeWithIdT> | null | undefined
 ): boolean {
 	const conditions = [
 		validateAliases(get(formData, 'aliasEditor', {})),

--- a/src/validators/series.ts
+++ b/src/validators/series.ts
@@ -18,7 +18,7 @@
  */
 
 
-import {get, validatePositiveInteger} from './base';
+import {ValidationError, get, validatePositiveInteger} from './base';
 import {
 	validateAliases,
 	validateIdentifiers,
@@ -27,38 +27,34 @@ import {
 } from './common';
 
 import type {IdentifierTypeWithIdT} from '../types/identifiers';
-import _ from 'lodash';
 
 
-export function validateSeriesSectionOrderingType(value: any): boolean {
-	return validatePositiveInteger(value, true);
+export function validateSeriesSectionOrderingType(value: any): void {
+	validatePositiveInteger(value, 'seriesSection.orderType', true);
 }
 
-export function validateSeriesSectionEntityType(value: any): boolean {
-	const entity = ['Author', 'Work', 'Edition', 'EditionGroup', 'Publisher'];
-	return entity.includes(value);
+export function validateSeriesSectionEntityType(value: any): void {
+	const itemEntityTypes = ['Author', 'Work', 'Edition', 'EditionGroup', 'Publisher'];
+	if (!itemEntityTypes.includes(value)) {
+		throw new ValidationError(
+			'Value is not an entity type which can be part of a series',
+			'seriesSection.seriesType',
+			value
+		);
+	}
 }
 
-export function validateSeriesSection(data: any): boolean {
-	return (
-		validateSeriesSectionOrderingType(get(data, 'orderType', null)) &&
-		validateSeriesSectionEntityType(get(data, 'seriesType', null))
-
-	);
+export function validateSeriesSection(data: any): void {
+	validateSeriesSectionOrderingType(get(data, 'orderType', null));
+	validateSeriesSectionEntityType(get(data, 'seriesType', null));
 }
 
-export function validateForm(
+export function validateSeries(
 	formData: any, identifierTypes?: Array<IdentifierTypeWithIdT> | null | undefined
-): boolean {
-	const conditions = [
-		validateAliases(get(formData, 'aliasEditor', {})),
-		validateIdentifiers(
-			get(formData, 'identifierEditor', {}), identifierTypes
-		),
-		validateNameSection(get(formData, 'nameSection', {})),
-		validateSeriesSection(get(formData, 'seriesSection', {})),
-		validateSubmissionSection(get(formData, 'submissionSection', {}))
-	];
-
-	return _.every(conditions);
+): void {
+	validateAliases(get(formData, 'aliasEditor', {}));
+	validateIdentifiers(get(formData, 'identifierEditor', {}), identifierTypes);
+	validateNameSection(get(formData, 'nameSection', {}));
+	validateSeriesSection(get(formData, 'seriesSection', {}));
+	validateSubmissionSection(get(formData, 'submissionSection', {}));
 }

--- a/src/validators/series.ts
+++ b/src/validators/series.ts
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2021  Akash Gupta
+ *               2024  David Kellner
  *
  *
  * This program is free software; you can redistribute it and/or modify

--- a/src/validators/work.ts
+++ b/src/validators/work.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2017  Ben Ockmore
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+
+import {get, validatePositiveInteger} from './base';
+import {
+	validateAliases, validateIdentifiers, validateNameSection,
+	validateSubmissionSection
+} from './common';
+import _ from 'lodash';
+import type {_IdentifierType} from '../../../types';
+
+
+export function validateWorkSectionType(value: any): boolean {
+	return validatePositiveInteger(value);
+}
+
+export function validateWorkSectionLanguage(value: any): boolean {
+	if (!value) {
+		return true;
+	}
+
+	return validatePositiveInteger(get(value, 'value', null), true);
+}
+
+export function validateWorkSection(data: any): boolean {
+	return (
+		validateWorkSectionType(get(data, 'type', null)) &&
+		validateWorkSectionLanguage(get(data, 'language', null))
+	);
+}
+
+export function validateForm(
+	formData: any, identifierTypes?: Array<_IdentifierType> | null | undefined
+): boolean {
+	const conditions = [
+		validateAliases(get(formData, 'aliasEditor', {})),
+		validateIdentifiers(
+			get(formData, 'identifierEditor', {}), identifierTypes
+		),
+		validateNameSection(get(formData, 'nameSection', {})),
+		validateWorkSection(get(formData, 'workSection', {})),
+		validateSubmissionSection(get(formData, 'submissionSection', {}))
+	];
+
+	return _.every(conditions);
+}

--- a/src/validators/work.ts
+++ b/src/validators/work.ts
@@ -23,40 +23,31 @@ import {
 	validateSubmissionSection
 } from './common';
 import type {IdentifierTypeWithIdT} from '../types/identifiers';
-import _ from 'lodash';
 
 
-export function validateWorkSectionType(value: any): boolean {
-	return validatePositiveInteger(value);
+export function validateWorkSectionType(value: any): void {
+	validatePositiveInteger(value, 'workSection.type');
 }
 
-export function validateWorkSectionLanguage(value: any): boolean {
+export function validateWorkSectionLanguage(value: any): void {
 	if (!value) {
-		return true;
+		return;
 	}
 
-	return validatePositiveInteger(get(value, 'value', null), true);
+	validatePositiveInteger(get(value, 'value', null), 'workSection.language', true);
 }
 
-export function validateWorkSection(data: any): boolean {
-	return (
-		validateWorkSectionType(get(data, 'type', null)) &&
-		validateWorkSectionLanguage(get(data, 'language', null))
-	);
+export function validateWorkSection(data: any): void {
+	validateWorkSectionType(get(data, 'type', null));
+	validateWorkSectionLanguage(get(data, 'language', null));
 }
 
-export function validateForm(
+export function validateWork(
 	formData: any, identifierTypes?: Array<IdentifierTypeWithIdT> | null | undefined
-): boolean {
-	const conditions = [
-		validateAliases(get(formData, 'aliasEditor', {})),
-		validateIdentifiers(
-			get(formData, 'identifierEditor', {}), identifierTypes
-		),
-		validateNameSection(get(formData, 'nameSection', {})),
-		validateWorkSection(get(formData, 'workSection', {})),
-		validateSubmissionSection(get(formData, 'submissionSection', {}))
-	];
-
-	return _.every(conditions);
+): void {
+	validateAliases(get(formData, 'aliasEditor', {}));
+	validateIdentifiers(get(formData, 'identifierEditor', {}), identifierTypes);
+	validateNameSection(get(formData, 'nameSection', {}));
+	validateWorkSection(get(formData, 'workSection', {}));
+	validateSubmissionSection(get(formData, 'submissionSection', {}));
 }

--- a/src/validators/work.ts
+++ b/src/validators/work.ts
@@ -22,8 +22,8 @@ import {
 	validateAliases, validateIdentifiers, validateNameSection,
 	validateSubmissionSection
 } from './common';
+import type {IdentifierTypeWithIdT} from '../types/identifiers';
 import _ from 'lodash';
-import type {_IdentifierType} from '../../../types';
 
 
 export function validateWorkSectionType(value: any): boolean {
@@ -46,7 +46,7 @@ export function validateWorkSection(data: any): boolean {
 }
 
 export function validateForm(
-	formData: any, identifierTypes?: Array<_IdentifierType> | null | undefined
+	formData: any, identifierTypes?: Array<IdentifierTypeWithIdT> | null | undefined
 ): boolean {
 	const conditions = [
 		validateAliases(get(formData, 'aliasEditor', {})),

--- a/src/validators/work.ts
+++ b/src/validators/work.ts
@@ -18,11 +18,12 @@
  */
 
 
-import {get, validatePositiveInteger} from './base';
 import {
+	LanguageStub,
 	validateAliases, validateIdentifiers, validateNameSection,
 	validateSubmissionSection
 } from './common';
+import {get, validatePositiveInteger} from './base';
 import type {IdentifierTypeWithIdT} from '../types/identifiers';
 
 
@@ -52,3 +53,8 @@ export function validateWork(
 	validateWorkSection(get(formData, 'workSection', {}));
 	validateSubmissionSection(get(formData, 'submissionSection', {}));
 }
+
+export type WorkSection = Partial<{
+	language: LanguageStub;
+	type: number;
+}>;

--- a/src/validators/work.ts
+++ b/src/validators/work.ts
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017  Ben Ockmore
+ *               2024  David Kellner
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/test/validators/data.js
+++ b/test/validators/data.js
@@ -1,0 +1,173 @@
+/*
+ * Copyright (C) 2017  Ben Ockmore
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+export const VALID_ALIAS = {
+	language: 1,
+	name: 'test',
+	primary: true,
+	sortName: 'test'
+};
+
+export const VALID_ALIASES = {
+	1: VALID_ALIAS,
+	n0: VALID_ALIAS
+};
+
+export const INVALID_ALIAS = {...VALID_ALIAS, language: null};
+
+export const INVALID_ALIASES = {
+	1: VALID_ALIAS,
+	n0: INVALID_ALIAS
+};
+
+export const VALID_IDENTIFIER = {
+	type: 1,
+	value: 'B076KQRJV1'
+};
+
+export const VALID_IDENTIFIERS = {
+	1: VALID_IDENTIFIER,
+	n0: VALID_IDENTIFIER
+};
+
+export const IDENTIFIER_TYPES = [{
+	id: 1,
+	validationRegex: /^(?:B\d{2}\w{7}|\d{9}[X\d])$/
+}];
+
+export const INVALID_IDENTIFIER = {...VALID_IDENTIFIERS, value: 'B076QRJV1'};
+
+export const INVALID_IDENTIFIERS = {
+	1: VALID_IDENTIFIERS,
+	n0: INVALID_IDENTIFIER
+};
+
+export const VALID_AUTHOR_CREDIT_ROW = {
+	author: {
+		id: 'cfbfe888-f5b5-4098-96cd-b0b98db2c4ba',
+		text: 'Isaac Asimov',
+		type: 'Author'
+	},
+	joinPhrase: '',
+	name: 'Isaac Asimov'
+};
+
+export const VALID_AUTHOR_CREDIT_EDITOR = {
+	1: VALID_AUTHOR_CREDIT_ROW,
+	n0: VALID_AUTHOR_CREDIT_ROW
+};
+
+export const INVALID_AUTHOR_CREDIT_ROW = {...VALID_AUTHOR_CREDIT_ROW, author: null};
+
+export const INVALID_AUTHOR_CREDIT_EDITOR = {
+	1: VALID_AUTHOR_CREDIT_ROW,
+	n0: INVALID_AUTHOR_CREDIT_ROW
+};
+
+export const VALID_NAME_SECTION = {
+	disambiguation: '',
+	language: 1,
+	name: 'test',
+	sortName: 'test'
+};
+
+export const INVALID_NAME_SECTION = {...VALID_NAME_SECTION, language: null};
+
+export const VALID_SUBMISSION_SECTION = {
+	note: 'blah'
+};
+
+export const EMPTY_SUBMISSION_SECTION = {
+	...VALID_SUBMISSION_SECTION, note: null
+};
+
+export const VALID_AREA = {id: 1};
+export const INVALID_AREA = {id: null};
+
+export const INVALID_DATES = [
+	// Incomplete dates
+	{day: '10', month: '', year: '2014'},
+	{day: '10', month: '02', year: ''},
+	{day: '10', month: '', year: ''},
+
+	/* Invalid day values */
+	{day: '0', month: '05', year: '2014'},
+	{day: '-1', month: '10', year: '2014'},
+	{day: 'a', month: '11', year: '2014'},
+	{day: '50', month: '08', year: '2014'},
+	{day: '31', month: '11', year: '2014'},
+	// Invalid day value (not a leap year)
+	{day: '29', month: '02', year: '2014'},
+
+	/* Invalid month values */
+	{day: '18', month: '0', year: '2014'},
+	{day: '18', month: '-1', year: '2014'},
+	{day: '18', month: 'a', year: '2014'},
+	{day: '18', month: '21', year: '2014'},
+
+	/* Invalid year values */
+	{day: '18', month: '11', year: 'asd'}
+
+];
+
+export const VALID_DATE_PAIR = [
+	{first: {day: '', month: '', year: ''}, second: {day: '', month: '', year: ''}},
+	{first: {day: '', month: '', year: ''}, second: {day: '', month: '', year: '1998'}},
+	{first: {day: '', month: '', year: ''}, second: {day: '', month: '10', year: '1998'}},
+	{first: {day: '', month: '', year: ''}, second: {day: '01', month: '01', year: '1998'}},
+	{first: {day: '', month: '', year: '1997'}, second: {day: '', month: '', year: ''}},
+	{first: {day: '', month: '', year: '1997'}, second: {day: '', month: '', year: '1998'}},
+	{first: {day: '', month: '', year: '1997'}, second: {day: '', month: '02', year: '1998'}},
+	{first: {day: '', month: '', year: '1997'}, second: {day: '01', month: '01', year: '1998'}},
+	{first: {day: '', month: '12', year: '1997'}, second: {day: '', month: '', year: ''}},
+	{first: {day: '', month: '12', year: '1997'}, second: {day: '', month: '', year: '1998'}},
+	{first: {day: '', month: '12', year: '1997'}, second: {day: '', month: '01', year: '1998'}},
+	{first: {day: '', month: '12', year: '1997'}, second: {day: '01', month: '01', year: '1998'}},
+	{first: {day: '31', month: '12', year: '1997'}, second: {day: '', month: '', year: ''}},
+	{first: {day: '31', month: '12', year: '1997'}, second: {day: '', month: '', year: '1998'}},
+	{first: {day: '31', month: '12', year: '1997'}, second: {day: '', month: '02', year: '1998'}},
+	{first: {day: '31', month: '12', year: '1997'}, second: {day: '01', month: '02', year: '1998'}},
+	{first: {day: '', month: '1', year: '2019'}, second: {day: '', month: '02', year: '2019'}},
+	{first: {day: '', month: '', year: '-900'}, second: {day: '', month: '', year: '-800'}},
+	{first: {day: '', month: '1', year: '-900'}, second: {day: '', month: '02', year: '-900'}},
+	{first: {day: '1', month: '1', year: '-900'}, second: {day: '02', month: '01', year: '-800'}}
+];
+export const INVALID_DATE_PAIR = [
+	{first: {day: '', month: '', year: '1998'}, second: {day: '', month: '', year: '1997'}},
+	{first: {day: '', month: '01', year: '1998'}, second: {day: '', month: '', year: '1997'}},
+	{first: {day: '01', month: '01', year: '1998'}, second: {day: '', month: '', year: '1997'}},
+	{first: {day: '', month: '', year: '1998'}, second: {day: '', month: '12', year: '1997'}},
+	{first: {day: '', month: '01', year: '1998'}, second: {day: '', month: '12', year: '1997'}},
+	{first: {day: '01', month: '01', year: '1998'}, second: {day: '', month: '12', year: '1997'}},
+	{first: {day: '', month: '', year: '1998'}, second: {day: '31', month: '12', year: '1997'}},
+	{first: {day: '', month: '01', year: '1998'}, second: {day: '31', month: '12', year: '1997'}},
+	{first: {day: '01', month: '01', year: '1998'}, second: {day: '31', month: '12', year: '1997'}},
+	{first: {day: '', month: '', year: '-800'}, second: {day: '', month: '', year: '-801'}}
+];
+export const INVALID_BEGIN_DATE_PAIR = [
+	// Begin date is invalid
+	{first: {day: '', month: '13', year: '1997'}, second: {day: '', month: '', year: '1992'}},
+	{first: {day: '41', month: '12', year: '1992'}, second: {day: '', month: '', year: ''}},
+	// Begin date is an invalid leap year
+	{first: {day: '29', month: '02', year: '2014'}, second: {day: '', month: '12', year: '1997'}}
+];
+export const INVALID_END_DATE_PAIR = [
+	{first: {day: '', month: '12', year: '1997'}, second: {day: '', month: '0', year: '1923'}},
+	// End date is an invalid leap year
+	{first: {day: '', month: '12', year: '1997'}, second: {day: '29', month: '02', year: '2014'}}
+];

--- a/test/validators/helpers.js
+++ b/test/validators/helpers.js
@@ -1,0 +1,209 @@
+/*
+ * Copyright (C) 2017  Ben Ockmore
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+import * as Immutable from 'immutable';
+import {
+	INVALID_AREA, INVALID_BEGIN_DATE_PAIR, INVALID_DATES, INVALID_DATE_PAIR,
+	INVALID_END_DATE_PAIR, VALID_AREA, VALID_DATE_PAIR
+} from './data';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+
+
+chai.use(chaiAsPromised);
+const {expect} = chai;
+
+export function testValidatePositiveIntegerFunc(
+	validationFunc, required = true
+) {
+	it('should pass any positive integer value', () => {
+		const result = validationFunc(1);
+		expect(result).to.be.true;
+	});
+
+	it('should reject zero', () => {
+		const result = validationFunc(0);
+		expect(result).to.be.false;
+	});
+
+	it('should reject an negative number', () => {
+		const result = validationFunc(-1);
+		expect(result).to.be.false;
+	});
+
+	it('should reject NaN', () => {
+		const result = validationFunc(NaN);
+		expect(result).to.be.false;
+	});
+
+	it('should reject any non-number value', () => {
+		const result = validationFunc({});
+		expect(result).to.be.false;
+	});
+
+	it(`should ${required ? 'reject' : 'pass'} a null value`, () => {
+		const result = validationFunc(null);
+		expect(result).to.equal(!required);
+	});
+}
+
+export function testValidateStringFunc(
+	validationFunc, required = true
+) {
+	it('should pass any non-empty string value', () => {
+		const result = validationFunc('test');
+		expect(result).to.be.true;
+	});
+
+	it('should reject an empty string', () => {
+		const result = validationFunc('');
+		expect(result).to.equal(!required);
+	});
+
+	it('should reject any non-string value', () => {
+		const result = validationFunc({});
+		expect(result).to.be.false;
+	});
+
+	it(`should ${required ? 'reject' : 'pass'} a null value`, () => {
+		const result = validationFunc(null);
+		expect(result).to.equal(!required);
+	});
+}
+
+export function testValidateBooleanFunc(validationFunc, required = true) {
+	it('should pass any boolean value', () => {
+		const result = validationFunc(true);
+		expect(result).to.be.true;
+	});
+
+	it('should reject any non-boolean value', () => {
+		const result = validationFunc({});
+		expect(result).to.be.false;
+	});
+
+	it(`should ${required ? 'reject' : 'pass'} a null value`, () => {
+		const result = validationFunc(null);
+		expect(result).to.equal(!required);
+	});
+}
+
+export function testValidateDateFunc(validationFunc, required = true) {
+	it('should pass an object containing a valid year value', () => {
+		const result = validationFunc({day: '', month: '', year: '2017'}).isValid;
+		expect(result).to.be.true;
+	});
+
+	it('should pass an object containing a valid year and month value', () => {
+		const result = validationFunc({day: '', month: '11', year: '2017'}).isValid;
+		expect(result).to.be.true;
+	});
+
+	it('should pass an object containing a valid year, month and day value', () => {
+		const result = validationFunc({day: '21', month: '11', year: '2017'}).isValid;
+		expect(result).to.be.true;
+	});
+
+	it('should reject all other forms of invalid dates', () => {
+		for (const date of INVALID_DATES) {
+			const result = validationFunc(date).isValid;
+			expect(result, `year '${date.year}', month '${date.month}', day '${date.day}'`).to.be.false;
+		}
+	});
+
+	it(`should ${required ? 'reject' : 'pass'} an empty value object`,
+		() => {
+			const result = validationFunc({}).isValid;
+			expect(result).to.equal(!required);
+		});
+}
+
+export function testValidateEndDateFunc(
+	endDateValidationFunc
+) {
+	it('should pass if the begin date occurs before the end one',
+		() => {
+			const result = VALID_DATE_PAIR.reduce((res, datePair) =>
+				res && endDateValidationFunc(datePair.first, datePair.second).isValid,
+			true);
+			expect(result).to.be.true;
+		});
+
+	it('should reject if the begin date occurs after the end one',
+		() => {
+			const result = INVALID_DATE_PAIR.reduce((res, datePair) =>
+				res || endDateValidationFunc(datePair.first, datePair.second).isValid,
+			false);
+			expect(result).to.be.false;
+		});
+
+	it('should pass if the begin date is empty/undefined/invalid',
+		() => {
+			const result = INVALID_BEGIN_DATE_PAIR.reduce((res, datePair) =>
+				res && endDateValidationFunc(datePair.first, datePair.second).isValid,
+			true);
+			expect(result).to.be.true;
+		});
+
+	it('should reject if the end date is invalid',
+		() => {
+			const result = INVALID_END_DATE_PAIR.reduce((res, datePair) =>
+				res || endDateValidationFunc(datePair.first, datePair.second).isValid,
+			false);
+			expect(result).to.be.false;
+		});
+}
+
+
+export function testValidateAreaFunc(validationFunc, required = true) {
+	it('should pass a valid Object', () => {
+		const result = validationFunc(VALID_AREA);
+		expect(result).to.be.true;
+	});
+
+	it('should pass a valid Immutable.Map', () => {
+		const result = validationFunc(
+			Immutable.fromJS(VALID_AREA)
+		);
+		expect(result).to.be.true;
+	});
+
+	it('should reject an Object with an invalid ID', () => {
+		const result = validationFunc(
+			{...VALID_AREA, id: null}
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should reject an invalid Immutable.Map', () => {
+		const result = validationFunc(
+			Immutable.fromJS(INVALID_AREA)
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should reject any other non-null data type', () => {
+		const result = validationFunc(1);
+		expect(result).to.be.false;
+	});
+
+	it(`should ${required ? 'reject' : 'pass'} a null value`, () => {
+		const result = validationFunc(null);
+		expect(result).to.equal(!required);
+	});
+}

--- a/test/validators/helpers.js
+++ b/test/validators/helpers.js
@@ -21,6 +21,7 @@ import {
 	INVALID_AREA, INVALID_BEGIN_DATE_PAIR, INVALID_DATES, INVALID_DATE_PAIR,
 	INVALID_END_DATE_PAIR, VALID_AREA, VALID_DATE_PAIR
 } from './data';
+import {ValidationError} from '../../lib/validators/base';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 
@@ -32,33 +33,28 @@ export function testValidatePositiveIntegerFunc(
 	validationFunc, required = true
 ) {
 	it('should pass any positive integer value', () => {
-		const result = validationFunc(1);
-		expect(result).to.be.true;
+		expect(() => validationFunc(1)).to.not.throw();
 	});
 
 	it('should reject zero', () => {
-		const result = validationFunc(0);
-		expect(result).to.be.false;
+		expect(() => validationFunc(0)).to.throw(ValidationError);
 	});
 
 	it('should reject an negative number', () => {
-		const result = validationFunc(-1);
-		expect(result).to.be.false;
+		expect(() => validationFunc(-1)).to.throw(ValidationError);
 	});
 
 	it('should reject NaN', () => {
-		const result = validationFunc(NaN);
-		expect(result).to.be.false;
+		expect(() => validationFunc(NaN)).to.throw(ValidationError);
 	});
 
 	it('should reject any non-number value', () => {
-		const result = validationFunc({});
-		expect(result).to.be.false;
+		expect(() => validationFunc({})).to.throw(ValidationError);
 	});
 
 	it(`should ${required ? 'reject' : 'pass'} a null value`, () => {
-		const result = validationFunc(null);
-		expect(result).to.equal(!required);
+		const expectedTo = expect(() => validationFunc(null)).to;
+		required ? expectedTo.throw(ValidationError) : expectedTo.not.throw();
 	});
 }
 
@@ -66,70 +62,65 @@ export function testValidateStringFunc(
 	validationFunc, required = true
 ) {
 	it('should pass any non-empty string value', () => {
-		const result = validationFunc('test');
-		expect(result).to.be.true;
+		expect(() => validationFunc('test')).to.not.throw();
 	});
 
-	it('should reject an empty string', () => {
-		const result = validationFunc('');
-		expect(result).to.equal(!required);
+	it(`should ${required ? 'reject' : 'pass'} an empty string`, () => {
+		const expectedTo = expect(() => validationFunc('')).to;
+		required ? expectedTo.throw(ValidationError) : expectedTo.not.throw();
 	});
 
 	it('should reject any non-string value', () => {
-		const result = validationFunc({});
-		expect(result).to.be.false;
+		expect(() => validationFunc({})).to.throw(ValidationError);
 	});
 
 	it(`should ${required ? 'reject' : 'pass'} a null value`, () => {
-		const result = validationFunc(null);
-		expect(result).to.equal(!required);
+		const expectedTo = expect(() => validationFunc(null)).to;
+		required ? expectedTo.throw(ValidationError) : expectedTo.not.throw();
 	});
 }
 
 export function testValidateBooleanFunc(validationFunc, required = true) {
 	it('should pass any boolean value', () => {
-		const result = validationFunc(true);
-		expect(result).to.be.true;
+		expect(() => validationFunc(true)).to.not.throw();
 	});
 
 	it('should reject any non-boolean value', () => {
-		const result = validationFunc({});
-		expect(result).to.be.false;
+		expect(() => validationFunc({})).to.throw(ValidationError);
 	});
 
 	it(`should ${required ? 'reject' : 'pass'} a null value`, () => {
-		const result = validationFunc(null);
-		expect(result).to.equal(!required);
+		const expectedTo = expect(() => validationFunc(null)).to;
+		required ? expectedTo.throw(ValidationError) : expectedTo.not.throw();
 	});
 }
 
 export function testValidateDateFunc(validationFunc, required = true) {
 	it('should pass an object containing a valid year value', () => {
-		const result = validationFunc({day: '', month: '', year: '2017'}).isValid;
-		expect(result).to.be.true;
+		expect(() => validationFunc({day: '', month: '', year: '2017'})).to.not.throw();
 	});
 
 	it('should pass an object containing a valid year and month value', () => {
-		const result = validationFunc({day: '', month: '11', year: '2017'}).isValid;
-		expect(result).to.be.true;
+		expect(() => validationFunc({day: '', month: '11', year: '2017'})).to.not.throw();
 	});
 
 	it('should pass an object containing a valid year, month and day value', () => {
-		const result = validationFunc({day: '21', month: '11', year: '2017'}).isValid;
-		expect(result).to.be.true;
+		expect(() => validationFunc({day: '21', month: '11', year: '2017'})).to.not.throw();
 	});
 
 	it('should reject all other forms of invalid dates', () => {
 		for (const date of INVALID_DATES) {
-			const result = validationFunc(date).isValid;
-			expect(result, `year '${date.year}', month '${date.month}', day '${date.day}'`).to.be.false;
+			expect(
+				() => validationFunc(date),
+				`year '${date.year}', month '${date.month}', day '${date.day}'`
+			).to.throw(ValidationError);
 		}
 	});
 
 	it(`should ${required ? 'reject' : 'pass'} an empty value object`,
 		() => {
-			const result = validationFunc({}).isValid;
-			expect(result).to.equal(!required);
+			const expectedTo = expect(() => validationFunc({})).to;
+			required ? expectedTo.throw(ValidationError) : expectedTo.not.throw();
 		});
 }
 
@@ -138,72 +129,67 @@ export function testValidateEndDateFunc(
 ) {
 	it('should pass if the begin date occurs before the end one',
 		() => {
-			const result = VALID_DATE_PAIR.reduce((res, datePair) =>
-				res && endDateValidationFunc(datePair.first, datePair.second).isValid,
-			true);
-			expect(result).to.be.true;
+			expect(() => {
+				for (const datePair of VALID_DATE_PAIR) {
+					endDateValidationFunc(datePair.first, datePair.second);
+				}
+			}).to.not.throw();
 		});
 
 	it('should reject if the begin date occurs after the end one',
 		() => {
-			const result = INVALID_DATE_PAIR.reduce((res, datePair) =>
-				res || endDateValidationFunc(datePair.first, datePair.second).isValid,
-			false);
-			expect(result).to.be.false;
+			for (const datePair of INVALID_DATE_PAIR) {
+				expect(() => endDateValidationFunc(datePair.first, datePair.second)).to.throw(ValidationError);
+			}
 		});
 
 	it('should pass if the begin date is empty/undefined/invalid',
 		() => {
-			const result = INVALID_BEGIN_DATE_PAIR.reduce((res, datePair) =>
-				res && endDateValidationFunc(datePair.first, datePair.second).isValid,
-			true);
-			expect(result).to.be.true;
+			expect(() => {
+				for (const datePair of INVALID_BEGIN_DATE_PAIR) {
+					endDateValidationFunc(datePair.first, datePair.second);
+				}
+			}).to.not.throw();
 		});
 
 	it('should reject if the end date is invalid',
 		() => {
-			const result = INVALID_END_DATE_PAIR.reduce((res, datePair) =>
-				res || endDateValidationFunc(datePair.first, datePair.second).isValid,
-			false);
-			expect(result).to.be.false;
+			for (const datePair of INVALID_END_DATE_PAIR) {
+				expect(() => endDateValidationFunc(datePair.first, datePair.second)).to.throw(ValidationError);
+			}
 		});
 }
 
 
 export function testValidateAreaFunc(validationFunc, required = true) {
 	it('should pass a valid Object', () => {
-		const result = validationFunc(VALID_AREA);
-		expect(result).to.be.true;
+		expect(() => validationFunc(VALID_AREA)).to.not.throw();
 	});
 
 	it('should pass a valid Immutable.Map', () => {
-		const result = validationFunc(
+		expect(() => validationFunc(
 			Immutable.fromJS(VALID_AREA)
-		);
-		expect(result).to.be.true;
+		)).to.not.throw();
 	});
 
 	it('should reject an Object with an invalid ID', () => {
-		const result = validationFunc(
+		expect(() => validationFunc(
 			{...VALID_AREA, id: null}
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should reject an invalid Immutable.Map', () => {
-		const result = validationFunc(
+		expect(() => validationFunc(
 			Immutable.fromJS(INVALID_AREA)
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should reject any other non-null data type', () => {
-		const result = validationFunc(1);
-		expect(result).to.be.false;
+		expect(() => validationFunc(1)).to.throw(ValidationError);
 	});
 
 	it(`should ${required ? 'reject' : 'pass'} a null value`, () => {
-		const result = validationFunc(null);
-		expect(result).to.equal(!required);
+		const expectedTo = expect(() => validationFunc(null)).to;
+		required ? expectedTo.throw(ValidationError) : expectedTo.not.throw();
 	});
 }

--- a/test/validators/test-alias.js
+++ b/test/validators/test-alias.js
@@ -25,7 +25,7 @@ import {
 	testValidateStringFunc
 } from './helpers';
 import {
-	validateAlias, validateAliasLanguage, validateAliasName,
+	validateAlias, validateAliasDefault, validateAliasLanguage, validateAliasName,
 	validateAliasPrimary, validateAliasSortName, validateAliases
 } from '../../lib/validators/common';
 import {ValidationError} from '../../lib/validators/base';
@@ -53,9 +53,17 @@ function describeValidateAliasPrimary() {
 	testValidateBooleanFunc(validateAliasPrimary);
 }
 
+function describeValidateAliasDefault() {
+	testValidateBooleanFunc(validateAliasDefault, false);
+}
+
 function describeValidateAlias() {
 	it('should pass a valid Object', () => {
 		expect(() => validateAlias(VALID_ALIAS)).to.not.throw();
+	});
+
+	it('should pass a valid Object with a default flag', () => {
+		expect(() => validateAlias({...VALID_ALIAS, default: true})).to.not.throw();
 	});
 
 	it('should pass a valid Immutable.Map', () => {
@@ -132,6 +140,7 @@ function tests() {
 	describe('validateAliasLanguage', describeValidateAliasLanguage);
 	describe('validateAlias', describeValidateAlias);
 	describe('validateAliasPrimary', describeValidateAliasPrimary);
+	describe('validateAliasDefault', describeValidateAliasDefault);
 	describe('validateAliases', describeValidateAliases);
 }
 

--- a/test/validators/test-alias.js
+++ b/test/validators/test-alias.js
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2017  Ben Ockmore
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+import * as Immutable from 'immutable';
+import {
+	INVALID_ALIAS, INVALID_ALIASES, VALID_ALIAS, VALID_ALIASES
+} from './data';
+import {
+	testValidateBooleanFunc, testValidatePositiveIntegerFunc,
+	testValidateStringFunc
+} from './helpers';
+import {
+	validateAlias, validateAliasLanguage, validateAliasName,
+	validateAliasPrimary, validateAliasSortName, validateAliases
+} from '../../lib/validators/common';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+
+
+chai.use(chaiAsPromised);
+const {expect} = chai;
+
+
+function describeValidateAliasName() {
+	testValidateStringFunc(validateAliasName);
+}
+
+function describeValidateAliasSortName() {
+	testValidateStringFunc(validateAliasSortName);
+}
+
+function describeValidateAliasLanguage() {
+	testValidatePositiveIntegerFunc(validateAliasLanguage);
+}
+
+function describeValidateAliasPrimary() {
+	testValidateBooleanFunc(validateAliasPrimary);
+}
+
+function describeValidateAlias() {
+	it('should pass a valid Object', () => {
+		const result = validateAlias(VALID_ALIAS);
+		expect(result).to.be.true;
+	});
+
+	it('should pass a valid Immutable.Map', () => {
+		const result = validateAlias(Immutable.fromJS(VALID_ALIAS));
+		expect(result).to.be.true;
+	});
+
+	it('should reject an Object with an invalid name', () => {
+		const result = validateAlias({...VALID_ALIAS, name: null});
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid sort name', () => {
+		const result = validateAlias({...VALID_ALIAS, sortName: null});
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid language', () => {
+		const result = validateAlias({...VALID_ALIAS, language: null});
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid primary', () => {
+		const result = validateAlias({...VALID_ALIAS, primary: null});
+		expect(result).to.be.false;
+	});
+
+	it('should reject an invalid Immutable.Map', () => {
+		const result = validateAlias(Immutable.fromJS(INVALID_ALIAS));
+		expect(result).to.be.false;
+	});
+
+	it('should reject any other non-null data type', () => {
+		const result = validateAlias(1);
+		expect(result).to.be.false;
+	});
+
+	it('should reject a null value', () => {
+		const result = validateAlias(null);
+		expect(result).to.be.false;
+	});
+}
+
+
+function describeValidateAliases() {
+	it('should pass an Object of two valid Objects', () => {
+		const result = validateAliases(VALID_ALIASES);
+		expect(result).to.be.true;
+	});
+
+	it('should pass an Immutable.Map of valid Immutable.Maps', () => {
+		const result = validateAliases(Immutable.fromJS(VALID_ALIASES));
+		expect(result).to.be.true;
+	});
+
+	it('should pass an empty Object', () => {
+		const result = validateAliases({});
+		expect(result).to.be.true;
+	});
+
+	it('should pass an empty Immutable.Map', () => {
+		const result = validateAliases(Immutable.Map());
+		expect(result).to.be.true;
+	});
+
+	it('should reject an Object containing one invalid Object', () => {
+		const result = validateAliases(INVALID_ALIASES);
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Immutable.Map containing one invalid Immutable.Map', () => {
+		const result = validateAliases(Immutable.fromJS(INVALID_ALIASES));
+		expect(result).to.be.false;
+	});
+
+	it('should reject any other non-null data type', () => {
+		const result = validateAliases(1);
+		expect(result).to.be.false;
+	});
+
+	it('should reject a null value', () => {
+		const result = validateAliases(null);
+		expect(result).to.be.false;
+	});
+}
+
+function tests() {
+	describe('validateAliasName', describeValidateAliasName);
+	describe('validateAliasSortName', describeValidateAliasSortName);
+	describe('validateAliasLanguage', describeValidateAliasLanguage);
+	describe('validateAlias', describeValidateAlias);
+	describe('validateAliasPrimary', describeValidateAliasPrimary);
+	describe('validateAliases', describeValidateAliases);
+}
+
+describe('validateAlias* functions', tests);

--- a/test/validators/test-alias.js
+++ b/test/validators/test-alias.js
@@ -28,6 +28,7 @@ import {
 	validateAlias, validateAliasLanguage, validateAliasName,
 	validateAliasPrimary, validateAliasSortName, validateAliases
 } from '../../lib/validators/common';
+import {ValidationError} from '../../lib/validators/base';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 
@@ -54,91 +55,74 @@ function describeValidateAliasPrimary() {
 
 function describeValidateAlias() {
 	it('should pass a valid Object', () => {
-		const result = validateAlias(VALID_ALIAS);
-		expect(result).to.be.true;
+		expect(() => validateAlias(VALID_ALIAS)).to.not.throw();
 	});
 
 	it('should pass a valid Immutable.Map', () => {
-		const result = validateAlias(Immutable.fromJS(VALID_ALIAS));
-		expect(result).to.be.true;
+		expect(() => validateAlias(Immutable.fromJS(VALID_ALIAS))).to.not.throw();
 	});
 
 	it('should reject an Object with an invalid name', () => {
-		const result = validateAlias({...VALID_ALIAS, name: null});
-		expect(result).to.be.false;
+		expect(() => validateAlias({...VALID_ALIAS, name: null})).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid sort name', () => {
-		const result = validateAlias({...VALID_ALIAS, sortName: null});
-		expect(result).to.be.false;
+		expect(() => validateAlias({...VALID_ALIAS, sortName: null})).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid language', () => {
-		const result = validateAlias({...VALID_ALIAS, language: null});
-		expect(result).to.be.false;
+		expect(() => validateAlias({...VALID_ALIAS, language: null})).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid primary', () => {
-		const result = validateAlias({...VALID_ALIAS, primary: null});
-		expect(result).to.be.false;
+		expect(() => validateAlias({...VALID_ALIAS, primary: null})).to.throw(ValidationError);
 	});
 
 	it('should reject an invalid Immutable.Map', () => {
-		const result = validateAlias(Immutable.fromJS(INVALID_ALIAS));
-		expect(result).to.be.false;
+		expect(() => validateAlias(Immutable.fromJS(INVALID_ALIAS))).to.throw(ValidationError);
 	});
 
 	it('should reject any other non-null data type', () => {
-		const result = validateAlias(1);
-		expect(result).to.be.false;
+		expect(() => validateAlias(1)).to.throw(ValidationError);
 	});
 
 	it('should reject a null value', () => {
-		const result = validateAlias(null);
-		expect(result).to.be.false;
+		expect(() => validateAlias(null)).to.throw(ValidationError);
 	});
 }
 
 
 function describeValidateAliases() {
 	it('should pass an Object of two valid Objects', () => {
-		const result = validateAliases(VALID_ALIASES);
-		expect(result).to.be.true;
+		expect(() => validateAliases(VALID_ALIASES)).to.not.throw();
 	});
 
 	it('should pass an Immutable.Map of valid Immutable.Maps', () => {
-		const result = validateAliases(Immutable.fromJS(VALID_ALIASES));
-		expect(result).to.be.true;
+		expect(() => validateAliases(Immutable.fromJS(VALID_ALIASES))).to.not.throw();
 	});
 
 	it('should pass an empty Object', () => {
-		const result = validateAliases({});
-		expect(result).to.be.true;
+		expect(() => validateAliases({})).to.not.throw();
 	});
 
 	it('should pass an empty Immutable.Map', () => {
-		const result = validateAliases(Immutable.Map());
-		expect(result).to.be.true;
+		expect(() => validateAliases(Immutable.Map())).to.not.throw();
 	});
 
 	it('should reject an Object containing one invalid Object', () => {
-		const result = validateAliases(INVALID_ALIASES);
-		expect(result).to.be.false;
+		expect(() => validateAliases(INVALID_ALIASES)).to.throw(ValidationError);
 	});
 
 	it('should reject an Immutable.Map containing one invalid Immutable.Map', () => {
-		const result = validateAliases(Immutable.fromJS(INVALID_ALIASES));
-		expect(result).to.be.false;
+		expect(() => validateAliases(Immutable.fromJS(INVALID_ALIASES))).to.throw(ValidationError);
 	});
 
 	it('should reject any other non-null data type', () => {
-		const result = validateAliases(1);
-		expect(result).to.be.false;
+		expect(() => validateAliases(1)).to.throw(ValidationError);
 	});
 
 	it('should reject a null value', () => {
-		const result = validateAliases(null);
-		expect(result).to.be.false;
+		expect(() => validateAliases(null)).to.throw(ValidationError);
 	});
 }
 

--- a/test/validators/test-author.js
+++ b/test/validators/test-author.js
@@ -48,6 +48,7 @@ import {
 	validateForm
 } from '../../lib/validators/author';
 
+import {ValidationError} from '../../lib/validators/base';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 
@@ -97,88 +98,76 @@ const INVALID_AUTHOR_SECTION = {...VALID_AUTHOR_SECTION, type: {}};
 
 function describeValidateAuthorSection() {
 	it('should pass a valid Object', () => {
-		const result = validateAuthorSection(VALID_AUTHOR_SECTION);
-		expect(result).to.be.true;
+		expect(() => validateAuthorSection(VALID_AUTHOR_SECTION)).to.not.throw();
 	});
 
 	it('should pass a valid Immutable.Map', () => {
-		const result = validateAuthorSection(
+		expect(() => validateAuthorSection(
 			Immutable.fromJS(VALID_AUTHOR_SECTION)
-		);
-		expect(result).to.be.true;
+		)).to.not.throw();
 	});
 
 	it('should reject an Object with an invalid area', () => {
-		const result = validateAuthorSection({
+		expect(() => validateAuthorSection({
 			...VALID_AUTHOR_SECTION,
 			beginArea: {id: null}
-		});
-		expect(result).to.be.false;
+		})).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid begin date', () => {
-		const result = validateAuthorSection({
+		expect(() => validateAuthorSection({
 			...VALID_AUTHOR_SECTION,
 			beginDate: {day: '100', month: '21', year: '2012'}
-		});
-		expect(result).to.be.false;
+		})).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid area', () => {
-		const result = validateAuthorSection({
+		expect(() => validateAuthorSection({
 			...VALID_AUTHOR_SECTION,
 			endArea: {id: null}
-		});
-		expect(result).to.be.false;
+		})).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid end date', () => {
-		const result = validateAuthorSection({
+		expect(() => validateAuthorSection({
 			...VALID_AUTHOR_SECTION,
 			endDate: {day: '', month: '', year: 'aaaa'}
-		});
-		expect(result).to.be.false;
+		})).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid ended flag', () => {
-		const result = validateAuthorSection({
+		expect(() => validateAuthorSection({
 			...VALID_AUTHOR_SECTION,
 			ended: 1
-		});
-		expect(result).to.be.false;
+		})).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid type', () => {
-		const result = validateAuthorSection({
+		expect(() => validateAuthorSection({
 			...VALID_AUTHOR_SECTION,
 			type: {}
-		});
-		expect(result).to.be.false;
+		})).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid gender', () => {
-		const result = validateAuthorSection({
+		expect(() => validateAuthorSection({
 			...VALID_AUTHOR_SECTION,
 			gender: {}
-		});
-		expect(result).to.be.false;
+		})).to.throw(ValidationError);
 	});
 
 	it('should reject an invalid Immutable.Map', () => {
-		const result = validateAuthorSection(
+		expect(() => validateAuthorSection(
 			Immutable.fromJS(INVALID_AUTHOR_SECTION)
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should pass any other non-null data type', () => {
-		const result = validateAuthorSection(1);
-		expect(result).to.be.true;
+		expect(() => validateAuthorSection(1)).to.not.throw();
 	});
 
 	it('should pass a empty value  object', () => {
-		const result = validateAuthorSection({day: '', month: '', year: ''});
-		expect(result).to.be.true;
+		expect(() => validateAuthorSection({day: '', month: '', year: ''})).to.not.throw();
 	});
 }
 
@@ -193,70 +182,63 @@ function describeValidateForm() {
 	};
 
 	it('should pass a valid Object', () => {
-		const result = validateForm(validForm, IDENTIFIER_TYPES);
-		expect(result).to.be.true;
+		expect(() => validateForm(validForm, IDENTIFIER_TYPES)).to.not.throw();
 	});
 
 	it('should pass a valid Immutable.Map', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			Immutable.fromJS(validForm),
 			IDENTIFIER_TYPES
-		);
-		expect(result).to.be.true;
+		)).to.not.throw();
 	});
 
 	it('should reject an Object with an invalid alias editor', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			{
 				...validForm,
 				aliasEditor: INVALID_ALIASES
 			},
 			IDENTIFIER_TYPES
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid identifier editor', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			{
 				...validForm,
 				identifierEditor: INVALID_IDENTIFIERS
 			}, IDENTIFIER_TYPES
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid name section', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			{
 				...validForm,
 				nameSection: INVALID_NAME_SECTION
 			},
 			IDENTIFIER_TYPES
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid author section', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			{
 				...validForm,
 				authorSection: INVALID_AUTHOR_SECTION
 			},
 			IDENTIFIER_TYPES
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should pass an Object with an empty submission section', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			{
 				...validForm,
 				submissionSection: EMPTY_SUBMISSION_SECTION
 			},
 			IDENTIFIER_TYPES
-		);
-		expect(result).to.be.true;
+		)).to.not.throw();
 	});
 
 	const invalidForm = {
@@ -266,21 +248,18 @@ function describeValidateForm() {
 	};
 
 	it('should reject an invalid Immutable.Map', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			Immutable.fromJS(invalidForm),
 			IDENTIFIER_TYPES
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should reject any other non-null data type', () => {
-		const result = validateForm(1, IDENTIFIER_TYPES);
-		expect(result).to.be.false;
+		expect(() => validateForm(1, IDENTIFIER_TYPES)).to.throw(ValidationError);
 	});
 
 	it('should reject a null value', () => {
-		const result = validateForm(null, IDENTIFIER_TYPES);
-		expect(result).to.be.false;
+		expect(() => validateForm(null, IDENTIFIER_TYPES)).to.throw(ValidationError);
 	});
 }
 

--- a/test/validators/test-author.js
+++ b/test/validators/test-author.js
@@ -37,6 +37,7 @@ import {
 	testValidatePositiveIntegerFunc
 } from './helpers';
 import {
+	validateAuthor,
 	validateAuthorSection,
 	validateAuthorSectionBeginArea,
 	validateAuthorSectionBeginDate,
@@ -44,8 +45,7 @@ import {
 	validateAuthorSectionEndDate,
 	validateAuthorSectionEnded,
 	validateAuthorSectionGender,
-	validateAuthorSectionType,
-	validateForm
+	validateAuthorSectionType
 } from '../../lib/validators/author';
 
 import {ValidationError} from '../../lib/validators/base';
@@ -182,18 +182,18 @@ function describeValidateForm() {
 	};
 
 	it('should pass a valid Object', () => {
-		expect(() => validateForm(validForm, IDENTIFIER_TYPES)).to.not.throw();
+		expect(() => validateAuthor(validForm, IDENTIFIER_TYPES)).to.not.throw();
 	});
 
 	it('should pass a valid Immutable.Map', () => {
-		expect(() => validateForm(
+		expect(() => validateAuthor(
 			Immutable.fromJS(validForm),
 			IDENTIFIER_TYPES
 		)).to.not.throw();
 	});
 
 	it('should reject an Object with an invalid alias editor', () => {
-		expect(() => validateForm(
+		expect(() => validateAuthor(
 			{
 				...validForm,
 				aliasEditor: INVALID_ALIASES
@@ -203,7 +203,7 @@ function describeValidateForm() {
 	});
 
 	it('should reject an Object with an invalid identifier editor', () => {
-		expect(() => validateForm(
+		expect(() => validateAuthor(
 			{
 				...validForm,
 				identifierEditor: INVALID_IDENTIFIERS
@@ -212,7 +212,7 @@ function describeValidateForm() {
 	});
 
 	it('should reject an Object with an invalid name section', () => {
-		expect(() => validateForm(
+		expect(() => validateAuthor(
 			{
 				...validForm,
 				nameSection: INVALID_NAME_SECTION
@@ -222,7 +222,7 @@ function describeValidateForm() {
 	});
 
 	it('should reject an Object with an invalid author section', () => {
-		expect(() => validateForm(
+		expect(() => validateAuthor(
 			{
 				...validForm,
 				authorSection: INVALID_AUTHOR_SECTION
@@ -232,7 +232,7 @@ function describeValidateForm() {
 	});
 
 	it('should pass an Object with an empty submission section', () => {
-		expect(() => validateForm(
+		expect(() => validateAuthor(
 			{
 				...validForm,
 				submissionSection: EMPTY_SUBMISSION_SECTION
@@ -248,18 +248,18 @@ function describeValidateForm() {
 	};
 
 	it('should reject an invalid Immutable.Map', () => {
-		expect(() => validateForm(
+		expect(() => validateAuthor(
 			Immutable.fromJS(invalidForm),
 			IDENTIFIER_TYPES
 		)).to.throw(ValidationError);
 	});
 
 	it('should reject any other non-null data type', () => {
-		expect(() => validateForm(1, IDENTIFIER_TYPES)).to.throw(ValidationError);
+		expect(() => validateAuthor(1, IDENTIFIER_TYPES)).to.throw(ValidationError);
 	});
 
 	it('should reject a null value', () => {
-		expect(() => validateForm(null, IDENTIFIER_TYPES)).to.throw(ValidationError);
+		expect(() => validateAuthor(null, IDENTIFIER_TYPES)).to.throw(ValidationError);
 	});
 }
 

--- a/test/validators/test-author.js
+++ b/test/validators/test-author.js
@@ -1,0 +1,327 @@
+/*
+ * Copyright (C) 2017  Ben Ockmore
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+import * as Immutable from 'immutable';
+
+import {
+	EMPTY_SUBMISSION_SECTION,
+	IDENTIFIER_TYPES,
+	INVALID_ALIASES,
+	INVALID_IDENTIFIERS,
+	INVALID_NAME_SECTION,
+	VALID_ALIASES,
+	VALID_IDENTIFIERS,
+	VALID_NAME_SECTION,
+	VALID_SUBMISSION_SECTION
+} from './data';
+import {
+	testValidateAreaFunc,
+	testValidateBooleanFunc,
+	testValidateDateFunc,
+	testValidateEndDateFunc,
+	testValidatePositiveIntegerFunc
+} from './helpers';
+import {
+	validateAuthorSection,
+	validateAuthorSectionBeginArea,
+	validateAuthorSectionBeginDate,
+	validateAuthorSectionEndArea,
+	validateAuthorSectionEndDate,
+	validateAuthorSectionEnded,
+	validateAuthorSectionGender,
+	validateAuthorSectionType,
+	validateForm
+} from '../../lib/validators/author';
+
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+
+
+chai.use(chaiAsPromised);
+const {expect} = chai;
+
+
+function describeValidateAuthorSectionBeginArea() {
+	testValidateAreaFunc(validateAuthorSectionBeginArea, false);
+}
+
+function describeValidateAuthorSectionEndArea() {
+	testValidateAreaFunc(validateAuthorSectionEndArea, false);
+}
+
+function describeValidateAuthorSectionBeginDate() {
+	testValidateDateFunc(validateAuthorSectionBeginDate, false);
+}
+
+function describeValidateAuthorSectionEndDate() {
+	testValidateEndDateFunc(validateAuthorSectionEndDate, false);
+}
+
+function describeValidateAuthorSectionEnded() {
+	testValidateBooleanFunc(validateAuthorSectionEnded, false);
+}
+
+function describeValidateAuthorSectionType() {
+	testValidatePositiveIntegerFunc(validateAuthorSectionType, false);
+}
+
+function describeValidateAuthorSectionGender() {
+	testValidatePositiveIntegerFunc(validateAuthorSectionGender, false);
+}
+
+const VALID_AUTHOR_SECTION = {
+	beginArea: null,
+	beginDate: '',
+	endArea: null,
+	endDate: '',
+	ended: true,
+	gender: 1,
+	type: 1
+};
+const INVALID_AUTHOR_SECTION = {...VALID_AUTHOR_SECTION, type: {}};
+
+function describeValidateAuthorSection() {
+	it('should pass a valid Object', () => {
+		const result = validateAuthorSection(VALID_AUTHOR_SECTION);
+		expect(result).to.be.true;
+	});
+
+	it('should pass a valid Immutable.Map', () => {
+		const result = validateAuthorSection(
+			Immutable.fromJS(VALID_AUTHOR_SECTION)
+		);
+		expect(result).to.be.true;
+	});
+
+	it('should reject an Object with an invalid area', () => {
+		const result = validateAuthorSection({
+			...VALID_AUTHOR_SECTION,
+			beginArea: {id: null}
+		});
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid begin date', () => {
+		const result = validateAuthorSection({
+			...VALID_AUTHOR_SECTION,
+			beginDate: {day: '100', month: '21', year: '2012'}
+		});
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid area', () => {
+		const result = validateAuthorSection({
+			...VALID_AUTHOR_SECTION,
+			endArea: {id: null}
+		});
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid end date', () => {
+		const result = validateAuthorSection({
+			...VALID_AUTHOR_SECTION,
+			endDate: {day: '', month: '', year: 'aaaa'}
+		});
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid ended flag', () => {
+		const result = validateAuthorSection({
+			...VALID_AUTHOR_SECTION,
+			ended: 1
+		});
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid type', () => {
+		const result = validateAuthorSection({
+			...VALID_AUTHOR_SECTION,
+			type: {}
+		});
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid gender', () => {
+		const result = validateAuthorSection({
+			...VALID_AUTHOR_SECTION,
+			gender: {}
+		});
+		expect(result).to.be.false;
+	});
+
+	it('should reject an invalid Immutable.Map', () => {
+		const result = validateAuthorSection(
+			Immutable.fromJS(INVALID_AUTHOR_SECTION)
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should pass any other non-null data type', () => {
+		const result = validateAuthorSection(1);
+		expect(result).to.be.true;
+	});
+
+	it('should pass a empty value  object', () => {
+		const result = validateAuthorSection({day: '', month: '', year: ''});
+		expect(result).to.be.true;
+	});
+}
+
+
+function describeValidateForm() {
+	const validForm = {
+		aliasEditor: VALID_ALIASES,
+		authorSection: VALID_AUTHOR_SECTION,
+		identifierEditor: VALID_IDENTIFIERS,
+		nameSection: VALID_NAME_SECTION,
+		submissionSection: VALID_SUBMISSION_SECTION
+	};
+
+	it('should pass a valid Object', () => {
+		const result = validateForm(validForm, IDENTIFIER_TYPES);
+		expect(result).to.be.true;
+	});
+
+	it('should pass a valid Immutable.Map', () => {
+		const result = validateForm(
+			Immutable.fromJS(validForm),
+			IDENTIFIER_TYPES
+		);
+		expect(result).to.be.true;
+	});
+
+	it('should reject an Object with an invalid alias editor', () => {
+		const result = validateForm(
+			{
+				...validForm,
+				aliasEditor: INVALID_ALIASES
+			},
+			IDENTIFIER_TYPES
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid identifier editor', () => {
+		const result = validateForm(
+			{
+				...validForm,
+				identifierEditor: INVALID_IDENTIFIERS
+			}, IDENTIFIER_TYPES
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid name section', () => {
+		const result = validateForm(
+			{
+				...validForm,
+				nameSection: INVALID_NAME_SECTION
+			},
+			IDENTIFIER_TYPES
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid author section', () => {
+		const result = validateForm(
+			{
+				...validForm,
+				authorSection: INVALID_AUTHOR_SECTION
+			},
+			IDENTIFIER_TYPES
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should pass an Object with an empty submission section', () => {
+		const result = validateForm(
+			{
+				...validForm,
+				submissionSection: EMPTY_SUBMISSION_SECTION
+			},
+			IDENTIFIER_TYPES
+		);
+		expect(result).to.be.true;
+	});
+
+	const invalidForm = {
+		...validForm,
+		authorSection: INVALID_AUTHOR_SECTION
+
+	};
+
+	it('should reject an invalid Immutable.Map', () => {
+		const result = validateForm(
+			Immutable.fromJS(invalidForm),
+			IDENTIFIER_TYPES
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should reject any other non-null data type', () => {
+		const result = validateForm(1, IDENTIFIER_TYPES);
+		expect(result).to.be.false;
+	});
+
+	it('should reject a null value', () => {
+		const result = validateForm(null, IDENTIFIER_TYPES);
+		expect(result).to.be.false;
+	});
+}
+
+
+function tests() {
+	describe(
+		'validateAuthorSectionBeginArea',
+		describeValidateAuthorSectionBeginArea
+	);
+	describe(
+		'validateAuthorSectionBeginDate',
+		describeValidateAuthorSectionBeginDate
+	);
+	describe(
+		'validateAuthorSectionEndArea',
+		describeValidateAuthorSectionEndArea
+	);
+	describe(
+		'validateAuthorSectionEndDate',
+		describeValidateAuthorSectionEndDate
+	);
+	describe(
+		'validateAuthorSectionEnded',
+		describeValidateAuthorSectionEnded
+	);
+	describe(
+		'validateAuthorSectionGender',
+		describeValidateAuthorSectionGender
+	);
+	describe(
+		'validateAuthorSectionType',
+		describeValidateAuthorSectionType
+	);
+	describe(
+		'validateAuthorSection',
+		describeValidateAuthorSection
+	);
+	describe(
+		'validateForm',
+		describeValidateForm
+	);
+}
+
+describe('validateAuthorSection* functions', tests);

--- a/test/validators/test-edition-group.js
+++ b/test/validators/test-edition-group.js
@@ -30,9 +30,9 @@ import {
 	VALID_SUBMISSION_SECTION
 } from './data';
 import {
+	validateEditionGroup,
 	validateEditionGroupSection,
-	validateEditionGroupSectionType,
-	validateForm
+	validateEditionGroupSectionType
 } from '../../lib/validators/edition-group';
 
 import {ValidationError} from '../../lib/validators/base';
@@ -111,18 +111,18 @@ function describeValidateForm() {
 	};
 
 	it('should pass a valid Object', () => {
-		expect(() => validateForm(validForm, IDENTIFIER_TYPES)).to.not.throw();
+		expect(() => validateEditionGroup(validForm, IDENTIFIER_TYPES)).to.not.throw();
 	});
 
 	it('should pass a valid Immutable.Map', () => {
-		expect(() => validateForm(
+		expect(() => validateEditionGroup(
 			Immutable.fromJS(validForm),
 			IDENTIFIER_TYPES
 		)).to.not.throw();
 	});
 
 	it('should reject an Object with an invalid alias editor', () => {
-		expect(() => validateForm(
+		expect(() => validateEditionGroup(
 			{
 				...validForm,
 				aliasEditor: INVALID_ALIASES
@@ -132,7 +132,7 @@ function describeValidateForm() {
 	});
 
 	it('should reject an Object with an invalid identifier editor', () => {
-		expect(() => validateForm(
+		expect(() => validateEditionGroup(
 			{
 				...validForm,
 				identifierEditor: INVALID_IDENTIFIERS
@@ -141,7 +141,7 @@ function describeValidateForm() {
 	});
 
 	it('should reject an Object with an invalid name section', () => {
-		expect(() => validateForm(
+		expect(() => validateEditionGroup(
 			{
 				...validForm,
 				nameSection: INVALID_NAME_SECTION
@@ -151,7 +151,7 @@ function describeValidateForm() {
 	});
 
 	it('should reject an Object with an invalid Edition Group section', () => {
-		expect(() => validateForm(
+		expect(() => validateEditionGroup(
 			{
 				...validForm,
 				editionGroupSection: INVALID_EDITION_GROUP_SECTION
@@ -161,7 +161,7 @@ function describeValidateForm() {
 	});
 
 	it('should pass an Object with an empty submission section', () => {
-		expect(() => validateForm(
+		expect(() => validateEditionGroup(
 			{
 				...validForm,
 				submissionSection: EMPTY_SUBMISSION_SECTION
@@ -176,18 +176,18 @@ function describeValidateForm() {
 	};
 
 	it('should reject an invalid Immutable.Map', () => {
-		expect(() => validateForm(
+		expect(() => validateEditionGroup(
 			Immutable.fromJS(invalidForm),
 			IDENTIFIER_TYPES
 		)).to.throw(ValidationError);
 	});
 
 	it('should reject any other non-null data type', () => {
-		expect(() => validateForm(1, IDENTIFIER_TYPES)).to.throw(ValidationError);
+		expect(() => validateEditionGroup(1, IDENTIFIER_TYPES)).to.throw(ValidationError);
 	});
 
 	it('should reject a null value', () => {
-		expect(() => validateForm(null, IDENTIFIER_TYPES)).to.throw(ValidationError);
+		expect(() => validateEditionGroup(null, IDENTIFIER_TYPES)).to.throw(ValidationError);
 	});
 }
 

--- a/test/validators/test-edition-group.js
+++ b/test/validators/test-edition-group.js
@@ -35,6 +35,7 @@ import {
 	validateForm
 } from '../../lib/validators/edition-group';
 
+import {ValidationError} from '../../lib/validators/base';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import {testValidatePositiveIntegerFunc} from './helpers';
@@ -67,40 +68,34 @@ const INVALID_EDITION_GROUP_SECTION = {...VALID_EDITION_GROUP_SECTION, type: {}}
 
 function describeValidateEditionGroupSection() {
 	it('should pass a valid Object', () => {
-		const result = validateEditionGroupSection(VALID_EDITION_GROUP_SECTION);
-		expect(result).to.be.true;
+		expect(() => validateEditionGroupSection(VALID_EDITION_GROUP_SECTION)).to.not.throw();
 	});
 
 	it('should pass a valid Immutable.Map', () => {
-		const result = validateEditionGroupSection(
+		expect(() => validateEditionGroupSection(
 			Immutable.fromJS(VALID_EDITION_GROUP_SECTION)
-		);
-		expect(result).to.be.true;
+		)).to.not.throw();
 	});
 
 	it('should reject an Object with an invalid type', () => {
-		const result = validateEditionGroupSection({
+		expect(() => validateEditionGroupSection({
 			...VALID_EDITION_GROUP_SECTION,
 			type: {}
-		});
-		expect(result).to.be.false;
+		})).to.throw(ValidationError);
 	});
 
 	it('should reject an invalid Immutable.Map', () => {
-		const result = validateEditionGroupSection(
+		expect(() => validateEditionGroupSection(
 			Immutable.fromJS(INVALID_EDITION_GROUP_SECTION)
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should pass any other non-null data type', () => {
-		const result = validateEditionGroupSection(1);
-		expect(result).to.be.true;
+		expect(() => validateEditionGroupSection(1)).to.not.throw();
 	});
 
 	it('should pass a null value', () => {
-		const result = validateEditionGroupSection(null);
-		expect(result).to.be.true;
+		expect(() => validateEditionGroupSection(null)).to.not.throw();
 	});
 }
 
@@ -116,70 +111,63 @@ function describeValidateForm() {
 	};
 
 	it('should pass a valid Object', () => {
-		const result = validateForm(validForm, IDENTIFIER_TYPES);
-		expect(result).to.be.true;
+		expect(() => validateForm(validForm, IDENTIFIER_TYPES)).to.not.throw();
 	});
 
 	it('should pass a valid Immutable.Map', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			Immutable.fromJS(validForm),
 			IDENTIFIER_TYPES
-		);
-		expect(result).to.be.true;
+		)).to.not.throw();
 	});
 
 	it('should reject an Object with an invalid alias editor', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			{
 				...validForm,
 				aliasEditor: INVALID_ALIASES
 			},
 			IDENTIFIER_TYPES
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid identifier editor', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			{
 				...validForm,
 				identifierEditor: INVALID_IDENTIFIERS
 			}, IDENTIFIER_TYPES
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid name section', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			{
 				...validForm,
 				nameSection: INVALID_NAME_SECTION
 			},
 			IDENTIFIER_TYPES
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid Edition Group section', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			{
 				...validForm,
 				editionGroupSection: INVALID_EDITION_GROUP_SECTION
 			},
 			IDENTIFIER_TYPES
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should pass an Object with an empty submission section', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			{
 				...validForm,
 				submissionSection: EMPTY_SUBMISSION_SECTION
 			},
 			IDENTIFIER_TYPES
-		);
-		expect(result).to.be.true;
+		)).to.not.throw();
 	});
 
 	const invalidForm = {
@@ -188,21 +176,18 @@ function describeValidateForm() {
 	};
 
 	it('should reject an invalid Immutable.Map', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			Immutable.fromJS(invalidForm),
 			IDENTIFIER_TYPES
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should reject any other non-null data type', () => {
-		const result = validateForm(1, IDENTIFIER_TYPES);
-		expect(result).to.be.false;
+		expect(() => validateForm(1, IDENTIFIER_TYPES)).to.throw(ValidationError);
 	});
 
 	it('should reject a null value', () => {
-		const result = validateForm(null, IDENTIFIER_TYPES);
-		expect(result).to.be.false;
+		expect(() => validateForm(null, IDENTIFIER_TYPES)).to.throw(ValidationError);
 	});
 }
 

--- a/test/validators/test-edition-group.js
+++ b/test/validators/test-edition-group.js
@@ -1,0 +1,225 @@
+/*
+ * Copyright (C) 2017  Ben Ockmore
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+import * as Immutable from 'immutable';
+
+import {
+	EMPTY_SUBMISSION_SECTION,
+	IDENTIFIER_TYPES,
+	INVALID_ALIASES,
+	INVALID_IDENTIFIERS,
+	INVALID_NAME_SECTION,
+	VALID_ALIASES,
+	VALID_IDENTIFIERS,
+	VALID_NAME_SECTION,
+	VALID_SUBMISSION_SECTION
+} from './data';
+import {
+	validateEditionGroupSection,
+	validateEditionGroupSectionType,
+	validateForm
+} from '../../lib/validators/edition-group';
+
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import {testValidatePositiveIntegerFunc} from './helpers';
+
+
+chai.use(chaiAsPromised);
+const {expect} = chai;
+
+
+function describeValidateEditionGroupSectionType() {
+	testValidatePositiveIntegerFunc(validateEditionGroupSectionType, false);
+}
+
+const VALID_AUTHOR_CREDIT_EDITOR = {
+	n0: {
+		author: {
+			id: '204f580d-7763-4660-9668-9a21736b5f6c',
+			rowId: 'n0',
+			text: '',
+			type: 'Author'
+		},
+		name: 'author'
+	}
+};
+
+const VALID_EDITION_GROUP_SECTION = {
+	type: 1
+};
+const INVALID_EDITION_GROUP_SECTION = {...VALID_EDITION_GROUP_SECTION, type: {}};
+
+function describeValidateEditionGroupSection() {
+	it('should pass a valid Object', () => {
+		const result = validateEditionGroupSection(VALID_EDITION_GROUP_SECTION);
+		expect(result).to.be.true;
+	});
+
+	it('should pass a valid Immutable.Map', () => {
+		const result = validateEditionGroupSection(
+			Immutable.fromJS(VALID_EDITION_GROUP_SECTION)
+		);
+		expect(result).to.be.true;
+	});
+
+	it('should reject an Object with an invalid type', () => {
+		const result = validateEditionGroupSection({
+			...VALID_EDITION_GROUP_SECTION,
+			type: {}
+		});
+		expect(result).to.be.false;
+	});
+
+	it('should reject an invalid Immutable.Map', () => {
+		const result = validateEditionGroupSection(
+			Immutable.fromJS(INVALID_EDITION_GROUP_SECTION)
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should pass any other non-null data type', () => {
+		const result = validateEditionGroupSection(1);
+		expect(result).to.be.true;
+	});
+
+	it('should pass a null value', () => {
+		const result = validateEditionGroupSection(null);
+		expect(result).to.be.true;
+	});
+}
+
+
+function describeValidateForm() {
+	const validForm = {
+		aliasEditor: VALID_ALIASES,
+		authorCreditEditor: VALID_AUTHOR_CREDIT_EDITOR,
+		editionGroupSection: VALID_EDITION_GROUP_SECTION,
+		identifierEditor: VALID_IDENTIFIERS,
+		nameSection: VALID_NAME_SECTION,
+		submissionSection: VALID_SUBMISSION_SECTION
+	};
+
+	it('should pass a valid Object', () => {
+		const result = validateForm(validForm, IDENTIFIER_TYPES);
+		expect(result).to.be.true;
+	});
+
+	it('should pass a valid Immutable.Map', () => {
+		const result = validateForm(
+			Immutable.fromJS(validForm),
+			IDENTIFIER_TYPES
+		);
+		expect(result).to.be.true;
+	});
+
+	it('should reject an Object with an invalid alias editor', () => {
+		const result = validateForm(
+			{
+				...validForm,
+				aliasEditor: INVALID_ALIASES
+			},
+			IDENTIFIER_TYPES
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid identifier editor', () => {
+		const result = validateForm(
+			{
+				...validForm,
+				identifierEditor: INVALID_IDENTIFIERS
+			}, IDENTIFIER_TYPES
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid name section', () => {
+		const result = validateForm(
+			{
+				...validForm,
+				nameSection: INVALID_NAME_SECTION
+			},
+			IDENTIFIER_TYPES
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid Edition Group section', () => {
+		const result = validateForm(
+			{
+				...validForm,
+				editionGroupSection: INVALID_EDITION_GROUP_SECTION
+			},
+			IDENTIFIER_TYPES
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should pass an Object with an empty submission section', () => {
+		const result = validateForm(
+			{
+				...validForm,
+				submissionSection: EMPTY_SUBMISSION_SECTION
+			},
+			IDENTIFIER_TYPES
+		);
+		expect(result).to.be.true;
+	});
+
+	const invalidForm = {
+		...validForm,
+		nameSection: INVALID_NAME_SECTION
+	};
+
+	it('should reject an invalid Immutable.Map', () => {
+		const result = validateForm(
+			Immutable.fromJS(invalidForm),
+			IDENTIFIER_TYPES
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should reject any other non-null data type', () => {
+		const result = validateForm(1, IDENTIFIER_TYPES);
+		expect(result).to.be.false;
+	});
+
+	it('should reject a null value', () => {
+		const result = validateForm(null, IDENTIFIER_TYPES);
+		expect(result).to.be.false;
+	});
+}
+
+
+function tests() {
+	describe(
+		'validateEditionGroupSectionType',
+		describeValidateEditionGroupSectionType
+	);
+	describe(
+		'validateEditionGroupSection',
+		describeValidateEditionGroupSection
+	);
+	describe(
+		'validateForm',
+		describeValidateForm
+	);
+}
+
+describe('validateEditionGroupSection* functions', tests);

--- a/test/validators/test-edition.js
+++ b/test/validators/test-edition.js
@@ -1,0 +1,633 @@
+/*
+ * Copyright (C) 2017  Ben Ockmore
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+import * as Immutable from 'immutable';
+
+import {
+	EMPTY_SUBMISSION_SECTION,
+	IDENTIFIER_TYPES,
+	INVALID_ALIASES,
+	INVALID_AUTHOR_CREDIT_EDITOR,
+	INVALID_IDENTIFIERS,
+	INVALID_NAME_SECTION,
+	VALID_ALIASES,
+	VALID_AUTHOR_CREDIT_EDITOR,
+	VALID_IDENTIFIERS,
+	VALID_NAME_SECTION,
+	VALID_SUBMISSION_SECTION
+} from './data';
+import {
+	testValidateDateFunc,
+	testValidatePositiveIntegerFunc
+} from './helpers';
+import {
+	validateEditionSection,
+	validateEditionSectionDepth,
+	validateEditionSectionEditionGroup,
+	validateEditionSectionFormat,
+	validateEditionSectionHeight,
+	validateEditionSectionLanguage,
+	validateEditionSectionLanguages,
+	validateEditionSectionPages,
+	validateEditionSectionPublisher,
+	validateEditionSectionReleaseDate,
+	validateEditionSectionStatus,
+	validateEditionSectionWeight,
+	validateEditionSectionWidth,
+	validateForm
+} from '../../lib/validators/edition';
+
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+
+
+chai.use(chaiAsPromised);
+const {expect} = chai;
+
+
+function describeValidateEditionSectionReleaseDate() {
+	testValidateDateFunc(validateEditionSectionReleaseDate, false);
+}
+
+function describeValidateEditionSectionDepth() {
+	testValidatePositiveIntegerFunc(validateEditionSectionDepth, false);
+}
+
+function describeValidateEditionSectionHeight() {
+	testValidatePositiveIntegerFunc(validateEditionSectionHeight, false);
+}
+
+function describeValidateEditionSectionPages() {
+	testValidatePositiveIntegerFunc(validateEditionSectionPages, false);
+}
+
+function describeValidateEditionSectionWeight() {
+	testValidatePositiveIntegerFunc(validateEditionSectionWeight, false);
+}
+
+function describeValidateEditionSectionWidth() {
+	testValidatePositiveIntegerFunc(validateEditionSectionWidth, false);
+}
+
+function describeValidateEditionSectionFormat() {
+	testValidatePositiveIntegerFunc(validateEditionSectionFormat, false);
+}
+
+function describeValidateEditionSectionStatus() {
+	testValidatePositiveIntegerFunc(validateEditionSectionStatus, false);
+}
+
+
+function describeValidateEditionSectionLanguage() {
+	const validLanguage = {value: 1};
+
+	it('should pass a valid Object', () => {
+		const result = validateEditionSectionLanguage(validLanguage);
+		expect(result).to.be.true;
+	});
+
+	it('should pass a valid Immutable.Map', () => {
+		const result = validateEditionSectionLanguage(
+			Immutable.fromJS(validLanguage)
+		);
+		expect(result).to.be.true;
+	});
+
+	it('should reject an Object with an invalid value', () => {
+		const result = validateEditionSectionLanguage(
+			{...validLanguage, value: null}
+		);
+		expect(result).to.be.false;
+	});
+
+	const invalidLanguage = {value: null};
+
+	it('should reject an invalid Immutable.Map', () => {
+		const result = validateEditionSectionLanguage(
+			Immutable.fromJS(invalidLanguage)
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should reject any other non-null data type', () => {
+		const result = validateEditionSectionLanguage(1);
+		expect(result).to.be.false;
+	});
+
+	it('should reject a null value', () => {
+		const result = validateEditionSectionLanguage(null);
+		expect(result).to.be.false;
+	});
+}
+
+const VALID_LANGUAGE = {value: 1};
+const VALID_LANGUAGES = [VALID_LANGUAGE, VALID_LANGUAGE];
+const INVALID_LANGUAGE = {value: null};
+const INVALID_LANGUAGES = [VALID_LANGUAGE, INVALID_LANGUAGE];
+
+function describeValidateEditionSectionLanguages() {
+	it('should pass an Array of two valid Objects', () => {
+		const result = validateEditionSectionLanguages(VALID_LANGUAGES);
+		expect(result).to.be.true;
+	});
+
+	it('should pass an Immutable.List of valid Immutable.Maps', () => {
+		const result = validateEditionSectionLanguages(
+			Immutable.fromJS(VALID_LANGUAGES)
+		);
+		expect(result).to.be.true;
+	});
+
+	it('should pass an empty Array', () => {
+		const result = validateEditionSectionLanguages([]);
+		expect(result).to.be.true;
+	});
+
+	it('should pass an empty Immutable.List', () => {
+		const result = validateEditionSectionLanguages(Immutable.List());
+		expect(result).to.be.true;
+	});
+
+	it('should reject an Array containing one invalid Object', () => {
+		const result = validateEditionSectionLanguages(INVALID_LANGUAGES);
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Immutable.List containing one invalid Immutable.Map', () => {
+		const result = validateEditionSectionLanguages(
+			Immutable.fromJS(INVALID_LANGUAGES)
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should reject any other non-null data type', () => {
+		const result = validateEditionSectionLanguages(1);
+		expect(result).to.be.false;
+	});
+
+	it('should pass a null value', () => {
+		const result = validateEditionSectionLanguages(null);
+		expect(result).to.be.true;
+	});
+}
+
+const VALID_PUBLISHERS = {0: {
+	id: '21675f5b-e9f8-4a6b-9aac-d3c965aa7d83'
+},
+1: {
+	id: '21675f5b-e9f8-4a6b-9aac-d3c965aa7d84'
+}};
+
+const INVALID_PUBLISHERS = {0: {
+	id: '21675f5b-e9f8-4a6b-9aac-d3c965aa7d83'
+},
+1: {
+	id: '2'
+}};
+
+const VALID_ENTITY = {
+	id: '21675f5b-e9f8-4a6b-9aac-d3c965aa7d83'
+};
+const INVALID_ENTITY = {
+	id: '2'
+};
+
+function describevalidateEditionSectionEditionGroup() {
+	it('should pass a valid Object', () => {
+		const result = validateEditionSectionEditionGroup(VALID_ENTITY);
+		expect(result).to.be.true;
+	});
+
+	it('should pass a valid Immutable.Map', () => {
+		const result = validateEditionSectionEditionGroup(
+			Immutable.fromJS(VALID_ENTITY)
+		);
+		expect(result).to.be.true;
+	});
+
+	it('should pass a null value', () => {
+		const result = validateEditionSectionEditionGroup(null);
+		expect(result).to.be.true;
+	});
+
+	it('should pass any other non-null data type with no ID', () => {
+		const result = validateEditionSectionEditionGroup(1);
+		expect(result).to.be.true;
+	});
+
+	it('should reject an Object with an invalid ID', () => {
+		const result = validateEditionSectionEditionGroup(
+			{...VALID_ENTITY, id: '2'}
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should reject an invalid Immutable.Map', () => {
+		const result = validateEditionSectionEditionGroup(
+			Immutable.fromJS(INVALID_ENTITY)
+		);
+		expect(result).to.be.false;
+	});
+}
+
+function describeValidateEditionSectionPublisher() {
+	it('should pass a valid Object', () => {
+		const result = validateEditionSectionPublisher(VALID_PUBLISHERS);
+		expect(result).to.be.true;
+	});
+
+	it('should pass a valid Immutable.Map', () => {
+		const result = validateEditionSectionPublisher(
+			Immutable.fromJS(VALID_PUBLISHERS)
+		);
+		expect(result).to.be.true;
+	});
+
+	it('should reject an Object with an invalid ID', () => {
+		const result = validateEditionSectionPublisher(
+			{INVALID_PUBLISHERS}
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should reject an invalid Immutable.Map', () => {
+		const result = validateEditionSectionPublisher(
+			Immutable.fromJS(INVALID_ENTITY)
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should reject any other non-null data type', () => {
+		const result = validateEditionSectionPublisher(1);
+		expect(result).to.be.false;
+	});
+
+	it('should pass a null value', () => {
+		const result = validateEditionSectionPublisher(null);
+		expect(result).to.be.true;
+	});
+}
+
+const VALID_EDITION_SECTION = {
+	depth: 26,
+	editionGroup: VALID_ENTITY,
+	format: 2,
+	height: 24,
+	languages: VALID_LANGUAGES,
+	pages: 25,
+	publisher: VALID_PUBLISHERS,
+	releaseDate: {day: '22', month: '12', year: '2017'},
+	status: 2,
+	weight: 23,
+	width: 22
+};
+const INVALID_EDITION_SECTION = {...VALID_EDITION_SECTION, format: {}};
+
+function describeValidateEditionSection() {
+	it('should pass a valid Object', () => {
+		const result = validateEditionSection(VALID_EDITION_SECTION);
+		expect(result).to.be.true;
+	});
+
+	it('should pass a valid Immutable.Map', () => {
+		const result = validateEditionSection(
+			Immutable.fromJS(VALID_EDITION_SECTION)
+		);
+		expect(result).to.be.true;
+	});
+
+	it('should pass a null value', () => {
+		const result = validateEditionSection(null);
+		expect(result).to.be.true;
+	});
+
+	it('should ignore any other non-null data type', () => {
+		const result = validateEditionSection(1);
+		expect(result).to.be.true;
+	});
+
+	it('should reject an Object with an invalid depth', () => {
+		const result = validateEditionSection({
+			...VALID_EDITION_SECTION,
+			depth: 'ashes'
+		});
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid format', () => {
+		const result = validateEditionSection({
+			...VALID_EDITION_SECTION,
+			format: 'to'
+		});
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid height', () => {
+		const result = validateEditionSection({
+			...VALID_EDITION_SECTION,
+			height: 'ashes'
+		});
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with invalid languages', () => {
+		const result = validateEditionSection({
+			...VALID_EDITION_SECTION,
+			languages: INVALID_LANGUAGES
+		});
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid pages', () => {
+		const result = validateEditionSection({
+			...VALID_EDITION_SECTION,
+			pages: 'is'
+		});
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid edition group', () => {
+		const result = validateEditionSection({
+			...VALID_EDITION_SECTION,
+			editionGroup: INVALID_ENTITY
+		});
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid publisher', () => {
+		const result = validateEditionSection({
+			...VALID_EDITION_SECTION,
+			publisher: INVALID_ENTITY
+		});
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid release date', () => {
+		const result = validateEditionSection({
+			...VALID_EDITION_SECTION,
+			releaseDate: {day: '', month: '', year: 'abcd'}
+		});
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid status', () => {
+		const result = validateEditionSection({
+			...VALID_EDITION_SECTION,
+			status: 'life'
+		});
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid weight', () => {
+		const result = validateEditionSection({
+			...VALID_EDITION_SECTION,
+			weight: 'on'
+		});
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid width', () => {
+		const result = validateEditionSection({
+			...VALID_EDITION_SECTION,
+			width: 'mars?'
+		});
+		expect(result).to.be.false;
+	});
+
+	it('should reject an invalid Immutable.Map', () => {
+		const result = validateEditionSection(
+			Immutable.fromJS(INVALID_EDITION_SECTION)
+		);
+		expect(result).to.be.false;
+	});
+}
+
+
+function describeValidateForm() {
+	const validForm = {
+		aliasEditor: VALID_ALIASES,
+		authorCreditEditor: VALID_AUTHOR_CREDIT_EDITOR,
+		editionSection: VALID_EDITION_SECTION,
+		identifierEditor: VALID_IDENTIFIERS,
+		nameSection: VALID_NAME_SECTION,
+		submissionSection: VALID_SUBMISSION_SECTION
+	};
+
+	it('should pass a valid Object', () => {
+		const result = validateForm(validForm, IDENTIFIER_TYPES);
+		expect(result).to.be.true;
+	});
+
+	it('should pass a valid Immutable.Map', () => {
+		const result = validateForm(
+			Immutable.fromJS(validForm),
+			IDENTIFIER_TYPES
+		);
+		expect(result).to.be.true;
+	});
+
+	it('should pass an Object with an empty author credit editor and AC disabled', () => {
+		const result = validateForm(
+			{
+				...validForm,
+				authorCreditEditor: {},
+				editionSection: {
+					...validForm.editionSection,
+					authorCreditEnable: false
+				}
+			},
+			IDENTIFIER_TYPES
+		);
+		expect(result).to.be.true;
+	});
+
+	it('should reject an Object with an invalid alias editor', () => {
+		const result = validateForm(
+			{
+				...validForm,
+				aliasEditor: INVALID_ALIASES
+			},
+			IDENTIFIER_TYPES
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid author credit editor', () => {
+		const result = validateForm(
+			{
+				...validForm,
+				authorCreditEditor: INVALID_AUTHOR_CREDIT_EDITOR
+			},
+			IDENTIFIER_TYPES
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an empty author credit editor', () => {
+		const result = validateForm(
+			{
+				...validForm,
+				authorCreditEditor: {}
+			},
+			IDENTIFIER_TYPES
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with a non empty author credit editor and AC disabled', () => {
+		const result = validateForm(
+			{
+				...validForm,
+				authorCreditEditor: VALID_AUTHOR_CREDIT_EDITOR,
+				editionSection: {
+					...validForm.editionSection,
+					authorCreditEnable: false
+				}
+			},
+			IDENTIFIER_TYPES
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid identifier editor', () => {
+		const result = validateForm(
+			{
+				...validForm,
+				identifierEditor: INVALID_IDENTIFIERS
+			}, IDENTIFIER_TYPES
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid name section', () => {
+		const result = validateForm(
+			{
+				...validForm,
+				nameSection: INVALID_NAME_SECTION
+			},
+			IDENTIFIER_TYPES
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid edition section', () => {
+		const result = validateForm(
+			{
+				...validForm,
+				editionSection: INVALID_EDITION_SECTION
+			},
+			IDENTIFIER_TYPES
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should pass an Object with an empty submission section', () => {
+		const result = validateForm(
+			{
+				...validForm,
+				submissionSection: EMPTY_SUBMISSION_SECTION
+			},
+			IDENTIFIER_TYPES
+		);
+		expect(result).to.be.true;
+	});
+
+	const invalidForm = {
+		...validForm,
+		nameSection: INVALID_NAME_SECTION
+	};
+
+	it('should reject an invalid Immutable.Map', () => {
+		const result = validateForm(
+			Immutable.fromJS(invalidForm),
+			IDENTIFIER_TYPES
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should reject any other non-null data type', () => {
+		const result = validateForm(1, IDENTIFIER_TYPES);
+		expect(result).to.be.false;
+	});
+
+	it('should reject a null value', () => {
+		const result = validateForm(null, IDENTIFIER_TYPES);
+		expect(result).to.be.false;
+	});
+}
+
+function tests() {
+	describe(
+		'validateEditionSectionReleaseDate',
+		describeValidateEditionSectionReleaseDate
+	);
+	describe(
+		'validateEditionSectionDepth',
+		describeValidateEditionSectionDepth
+	);
+	describe(
+		'validateEditionSectionHeight',
+		describeValidateEditionSectionHeight
+	);
+	describe(
+		'validateEditionSectionPages',
+		describeValidateEditionSectionPages
+	);
+	describe(
+		'validateEditionSectionWeight',
+		describeValidateEditionSectionWeight
+	);
+	describe(
+		'validateEditionSectionWidth',
+		describeValidateEditionSectionWidth
+	);
+	describe(
+		'validateEditionSectionFormat',
+		describeValidateEditionSectionFormat
+	);
+	describe(
+		'validateEditionSectionStatus',
+		describeValidateEditionSectionStatus
+	);
+	describe(
+		'validateEditionSectionLanguage',
+		describeValidateEditionSectionLanguage
+	);
+	describe(
+		'validateEditionSectionLanguages',
+		describeValidateEditionSectionLanguages
+	);
+	describe(
+		'validateEditionSectionEditionGroup',
+		describevalidateEditionSectionEditionGroup
+	);
+	describe(
+		'validateEditionSectionPublisher',
+		describeValidateEditionSectionPublisher
+	);
+	describe(
+		'validateEditionSection',
+		describeValidateEditionSection
+	);
+	describe(
+		'validateForm',
+		describeValidateForm
+	);
+}
+
+describe('validateEditionSection* functions', tests);

--- a/test/validators/test-edition.js
+++ b/test/validators/test-edition.js
@@ -52,6 +52,7 @@ import {
 	validateForm
 } from '../../lib/validators/edition';
 
+import {ValidationError} from '../../lib/validators/base';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 
@@ -97,41 +98,35 @@ function describeValidateEditionSectionLanguage() {
 	const validLanguage = {value: 1};
 
 	it('should pass a valid Object', () => {
-		const result = validateEditionSectionLanguage(validLanguage);
-		expect(result).to.be.true;
+		expect(() => validateEditionSectionLanguage(validLanguage)).to.not.throw();
 	});
 
 	it('should pass a valid Immutable.Map', () => {
-		const result = validateEditionSectionLanguage(
+		expect(() => validateEditionSectionLanguage(
 			Immutable.fromJS(validLanguage)
-		);
-		expect(result).to.be.true;
+		)).to.not.throw();
 	});
 
 	it('should reject an Object with an invalid value', () => {
-		const result = validateEditionSectionLanguage(
+		expect(() => validateEditionSectionLanguage(
 			{...validLanguage, value: null}
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	const invalidLanguage = {value: null};
 
 	it('should reject an invalid Immutable.Map', () => {
-		const result = validateEditionSectionLanguage(
+		expect(() => validateEditionSectionLanguage(
 			Immutable.fromJS(invalidLanguage)
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should reject any other non-null data type', () => {
-		const result = validateEditionSectionLanguage(1);
-		expect(result).to.be.false;
+		expect(() => validateEditionSectionLanguage(1)).to.throw(ValidationError);
 	});
 
 	it('should reject a null value', () => {
-		const result = validateEditionSectionLanguage(null);
-		expect(result).to.be.false;
+		expect(() => validateEditionSectionLanguage(null)).to.throw(ValidationError);
 	});
 }
 
@@ -142,47 +137,39 @@ const INVALID_LANGUAGES = [VALID_LANGUAGE, INVALID_LANGUAGE];
 
 function describeValidateEditionSectionLanguages() {
 	it('should pass an Array of two valid Objects', () => {
-		const result = validateEditionSectionLanguages(VALID_LANGUAGES);
-		expect(result).to.be.true;
+		expect(() => validateEditionSectionLanguages(VALID_LANGUAGES)).to.not.throw();
 	});
 
 	it('should pass an Immutable.List of valid Immutable.Maps', () => {
-		const result = validateEditionSectionLanguages(
+		expect(() => validateEditionSectionLanguages(
 			Immutable.fromJS(VALID_LANGUAGES)
-		);
-		expect(result).to.be.true;
+		)).to.not.throw();
 	});
 
 	it('should pass an empty Array', () => {
-		const result = validateEditionSectionLanguages([]);
-		expect(result).to.be.true;
+		expect(() => validateEditionSectionLanguages([])).to.not.throw();
 	});
 
 	it('should pass an empty Immutable.List', () => {
-		const result = validateEditionSectionLanguages(Immutable.List());
-		expect(result).to.be.true;
+		expect(() => validateEditionSectionLanguages(Immutable.List())).to.not.throw();
 	});
 
 	it('should reject an Array containing one invalid Object', () => {
-		const result = validateEditionSectionLanguages(INVALID_LANGUAGES);
-		expect(result).to.be.false;
+		expect(() => validateEditionSectionLanguages(INVALID_LANGUAGES)).to.throw(ValidationError);
 	});
 
 	it('should reject an Immutable.List containing one invalid Immutable.Map', () => {
-		const result = validateEditionSectionLanguages(
+		expect(() => validateEditionSectionLanguages(
 			Immutable.fromJS(INVALID_LANGUAGES)
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should reject any other non-null data type', () => {
-		const result = validateEditionSectionLanguages(1);
-		expect(result).to.be.false;
+		expect(() => validateEditionSectionLanguages(1)).to.throw(ValidationError);
 	});
 
 	it('should pass a null value', () => {
-		const result = validateEditionSectionLanguages(null);
-		expect(result).to.be.true;
+		expect(() => validateEditionSectionLanguages(null)).to.not.throw();
 	});
 }
 
@@ -207,79 +194,67 @@ const INVALID_ENTITY = {
 	id: '2'
 };
 
-function describevalidateEditionSectionEditionGroup() {
+function describeValidateEditionSectionEditionGroup() {
 	it('should pass a valid Object', () => {
-		const result = validateEditionSectionEditionGroup(VALID_ENTITY);
-		expect(result).to.be.true;
+		expect(() => validateEditionSectionEditionGroup(VALID_ENTITY)).to.not.throw();
 	});
 
 	it('should pass a valid Immutable.Map', () => {
-		const result = validateEditionSectionEditionGroup(
+		expect(() => validateEditionSectionEditionGroup(
 			Immutable.fromJS(VALID_ENTITY)
-		);
-		expect(result).to.be.true;
+		)).to.not.throw();
 	});
 
 	it('should pass a null value', () => {
-		const result = validateEditionSectionEditionGroup(null);
-		expect(result).to.be.true;
+		expect(() => validateEditionSectionEditionGroup(null)).to.not.throw();
 	});
 
 	it('should pass any other non-null data type with no ID', () => {
-		const result = validateEditionSectionEditionGroup(1);
-		expect(result).to.be.true;
+		expect(() => validateEditionSectionEditionGroup(1)).to.not.throw();
 	});
 
 	it('should reject an Object with an invalid ID', () => {
-		const result = validateEditionSectionEditionGroup(
+		expect(() => validateEditionSectionEditionGroup(
 			{...VALID_ENTITY, id: '2'}
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should reject an invalid Immutable.Map', () => {
-		const result = validateEditionSectionEditionGroup(
+		expect(() => validateEditionSectionEditionGroup(
 			Immutable.fromJS(INVALID_ENTITY)
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 }
 
 function describeValidateEditionSectionPublisher() {
 	it('should pass a valid Object', () => {
-		const result = validateEditionSectionPublisher(VALID_PUBLISHERS);
-		expect(result).to.be.true;
+		expect(() => validateEditionSectionPublisher(VALID_PUBLISHERS)).to.not.throw();
 	});
 
 	it('should pass a valid Immutable.Map', () => {
-		const result = validateEditionSectionPublisher(
+		expect(() => validateEditionSectionPublisher(
 			Immutable.fromJS(VALID_PUBLISHERS)
-		);
-		expect(result).to.be.true;
+		)).to.not.throw();
 	});
 
 	it('should reject an Object with an invalid ID', () => {
-		const result = validateEditionSectionPublisher(
+		expect(() => validateEditionSectionPublisher(
 			{INVALID_PUBLISHERS}
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should reject an invalid Immutable.Map', () => {
-		const result = validateEditionSectionPublisher(
+		expect(() => validateEditionSectionPublisher(
 			Immutable.fromJS(INVALID_ENTITY)
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should reject any other non-null data type', () => {
-		const result = validateEditionSectionPublisher(1);
-		expect(result).to.be.false;
+		expect(() => validateEditionSectionPublisher(1)).to.throw(ValidationError);
 	});
 
 	it('should pass a null value', () => {
-		const result = validateEditionSectionPublisher(null);
-		expect(result).to.be.true;
+		expect(() => validateEditionSectionPublisher(null)).to.not.throw();
 	});
 }
 
@@ -300,120 +275,104 @@ const INVALID_EDITION_SECTION = {...VALID_EDITION_SECTION, format: {}};
 
 function describeValidateEditionSection() {
 	it('should pass a valid Object', () => {
-		const result = validateEditionSection(VALID_EDITION_SECTION);
-		expect(result).to.be.true;
+		expect(() => validateEditionSection(VALID_EDITION_SECTION)).to.not.throw();
 	});
 
 	it('should pass a valid Immutable.Map', () => {
-		const result = validateEditionSection(
+		expect(() => validateEditionSection(
 			Immutable.fromJS(VALID_EDITION_SECTION)
-		);
-		expect(result).to.be.true;
+		)).to.not.throw();
 	});
 
 	it('should pass a null value', () => {
-		const result = validateEditionSection(null);
-		expect(result).to.be.true;
+		expect(() => validateEditionSection(null)).to.not.throw();
 	});
 
 	it('should ignore any other non-null data type', () => {
-		const result = validateEditionSection(1);
-		expect(result).to.be.true;
+		expect(() => validateEditionSection(1)).to.not.throw();
 	});
 
 	it('should reject an Object with an invalid depth', () => {
-		const result = validateEditionSection({
+		expect(() => validateEditionSection({
 			...VALID_EDITION_SECTION,
 			depth: 'ashes'
-		});
-		expect(result).to.be.false;
+		})).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid format', () => {
-		const result = validateEditionSection({
+		expect(() => validateEditionSection({
 			...VALID_EDITION_SECTION,
 			format: 'to'
-		});
-		expect(result).to.be.false;
+		})).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid height', () => {
-		const result = validateEditionSection({
+		expect(() => validateEditionSection({
 			...VALID_EDITION_SECTION,
 			height: 'ashes'
-		});
-		expect(result).to.be.false;
+		})).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with invalid languages', () => {
-		const result = validateEditionSection({
+		expect(() => validateEditionSection({
 			...VALID_EDITION_SECTION,
 			languages: INVALID_LANGUAGES
-		});
-		expect(result).to.be.false;
+		})).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid pages', () => {
-		const result = validateEditionSection({
+		expect(() => validateEditionSection({
 			...VALID_EDITION_SECTION,
 			pages: 'is'
-		});
-		expect(result).to.be.false;
+		})).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid edition group', () => {
-		const result = validateEditionSection({
+		expect(() => validateEditionSection({
 			...VALID_EDITION_SECTION,
 			editionGroup: INVALID_ENTITY
-		});
-		expect(result).to.be.false;
+		})).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid publisher', () => {
-		const result = validateEditionSection({
+		expect(() => validateEditionSection({
 			...VALID_EDITION_SECTION,
 			publisher: INVALID_ENTITY
-		});
-		expect(result).to.be.false;
+		})).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid release date', () => {
-		const result = validateEditionSection({
+		expect(() => validateEditionSection({
 			...VALID_EDITION_SECTION,
 			releaseDate: {day: '', month: '', year: 'abcd'}
-		});
-		expect(result).to.be.false;
+		})).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid status', () => {
-		const result = validateEditionSection({
+		expect(() => validateEditionSection({
 			...VALID_EDITION_SECTION,
 			status: 'life'
-		});
-		expect(result).to.be.false;
+		})).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid weight', () => {
-		const result = validateEditionSection({
+		expect(() => validateEditionSection({
 			...VALID_EDITION_SECTION,
 			weight: 'on'
-		});
-		expect(result).to.be.false;
+		})).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid width', () => {
-		const result = validateEditionSection({
+		expect(() => validateEditionSection({
 			...VALID_EDITION_SECTION,
 			width: 'mars?'
-		});
-		expect(result).to.be.false;
+		})).to.throw(ValidationError);
 	});
 
 	it('should reject an invalid Immutable.Map', () => {
-		const result = validateEditionSection(
+		expect(() => validateEditionSection(
 			Immutable.fromJS(INVALID_EDITION_SECTION)
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 }
 
@@ -429,20 +388,18 @@ function describeValidateForm() {
 	};
 
 	it('should pass a valid Object', () => {
-		const result = validateForm(validForm, IDENTIFIER_TYPES);
-		expect(result).to.be.true;
+		expect(() => validateForm(validForm, IDENTIFIER_TYPES)).to.not.throw();
 	});
 
 	it('should pass a valid Immutable.Map', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			Immutable.fromJS(validForm),
 			IDENTIFIER_TYPES
-		);
-		expect(result).to.be.true;
+		)).to.not.throw();
 	});
 
 	it('should pass an Object with an empty author credit editor and AC disabled', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			{
 				...validForm,
 				authorCreditEditor: {},
@@ -452,45 +409,41 @@ function describeValidateForm() {
 				}
 			},
 			IDENTIFIER_TYPES
-		);
-		expect(result).to.be.true;
+		)).to.not.throw();
 	});
 
 	it('should reject an Object with an invalid alias editor', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			{
 				...validForm,
 				aliasEditor: INVALID_ALIASES
 			},
 			IDENTIFIER_TYPES
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid author credit editor', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			{
 				...validForm,
 				authorCreditEditor: INVALID_AUTHOR_CREDIT_EDITOR
 			},
 			IDENTIFIER_TYPES
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an empty author credit editor', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			{
 				...validForm,
 				authorCreditEditor: {}
 			},
 			IDENTIFIER_TYPES
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with a non empty author credit editor and AC disabled', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			{
 				...validForm,
 				authorCreditEditor: VALID_AUTHOR_CREDIT_EDITOR,
@@ -500,51 +453,46 @@ function describeValidateForm() {
 				}
 			},
 			IDENTIFIER_TYPES
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid identifier editor', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			{
 				...validForm,
 				identifierEditor: INVALID_IDENTIFIERS
 			}, IDENTIFIER_TYPES
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid name section', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			{
 				...validForm,
 				nameSection: INVALID_NAME_SECTION
 			},
 			IDENTIFIER_TYPES
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid edition section', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			{
 				...validForm,
 				editionSection: INVALID_EDITION_SECTION
 			},
 			IDENTIFIER_TYPES
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should pass an Object with an empty submission section', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			{
 				...validForm,
 				submissionSection: EMPTY_SUBMISSION_SECTION
 			},
 			IDENTIFIER_TYPES
-		);
-		expect(result).to.be.true;
+		)).to.not.throw();
 	});
 
 	const invalidForm = {
@@ -553,21 +501,18 @@ function describeValidateForm() {
 	};
 
 	it('should reject an invalid Immutable.Map', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			Immutable.fromJS(invalidForm),
 			IDENTIFIER_TYPES
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should reject any other non-null data type', () => {
-		const result = validateForm(1, IDENTIFIER_TYPES);
-		expect(result).to.be.false;
+		expect(() => validateForm(1, IDENTIFIER_TYPES)).to.throw(ValidationError);
 	});
 
 	it('should reject a null value', () => {
-		const result = validateForm(null, IDENTIFIER_TYPES);
-		expect(result).to.be.false;
+		expect(() => validateForm(null, IDENTIFIER_TYPES)).to.throw(ValidationError);
 	});
 }
 
@@ -614,7 +559,7 @@ function tests() {
 	);
 	describe(
 		'validateEditionSectionEditionGroup',
-		describevalidateEditionSectionEditionGroup
+		describeValidateEditionSectionEditionGroup
 	);
 	describe(
 		'validateEditionSectionPublisher',

--- a/test/validators/test-edition.js
+++ b/test/validators/test-edition.js
@@ -36,6 +36,7 @@ import {
 	testValidatePositiveIntegerFunc
 } from './helpers';
 import {
+	validateEdition,
 	validateEditionSection,
 	validateEditionSectionDepth,
 	validateEditionSectionEditionGroup,
@@ -48,8 +49,7 @@ import {
 	validateEditionSectionReleaseDate,
 	validateEditionSectionStatus,
 	validateEditionSectionWeight,
-	validateEditionSectionWidth,
-	validateForm
+	validateEditionSectionWidth
 } from '../../lib/validators/edition';
 
 import {ValidationError} from '../../lib/validators/base';
@@ -388,18 +388,18 @@ function describeValidateForm() {
 	};
 
 	it('should pass a valid Object', () => {
-		expect(() => validateForm(validForm, IDENTIFIER_TYPES)).to.not.throw();
+		expect(() => validateEdition(validForm, IDENTIFIER_TYPES)).to.not.throw();
 	});
 
 	it('should pass a valid Immutable.Map', () => {
-		expect(() => validateForm(
+		expect(() => validateEdition(
 			Immutable.fromJS(validForm),
 			IDENTIFIER_TYPES
 		)).to.not.throw();
 	});
 
 	it('should pass an Object with an empty author credit editor and AC disabled', () => {
-		expect(() => validateForm(
+		expect(() => validateEdition(
 			{
 				...validForm,
 				authorCreditEditor: {},
@@ -413,7 +413,7 @@ function describeValidateForm() {
 	});
 
 	it('should reject an Object with an invalid alias editor', () => {
-		expect(() => validateForm(
+		expect(() => validateEdition(
 			{
 				...validForm,
 				aliasEditor: INVALID_ALIASES
@@ -423,7 +423,7 @@ function describeValidateForm() {
 	});
 
 	it('should reject an Object with an invalid author credit editor', () => {
-		expect(() => validateForm(
+		expect(() => validateEdition(
 			{
 				...validForm,
 				authorCreditEditor: INVALID_AUTHOR_CREDIT_EDITOR
@@ -433,7 +433,7 @@ function describeValidateForm() {
 	});
 
 	it('should reject an Object with an empty author credit editor', () => {
-		expect(() => validateForm(
+		expect(() => validateEdition(
 			{
 				...validForm,
 				authorCreditEditor: {}
@@ -443,7 +443,7 @@ function describeValidateForm() {
 	});
 
 	it('should reject an Object with a non empty author credit editor and AC disabled', () => {
-		expect(() => validateForm(
+		expect(() => validateEdition(
 			{
 				...validForm,
 				authorCreditEditor: VALID_AUTHOR_CREDIT_EDITOR,
@@ -457,7 +457,7 @@ function describeValidateForm() {
 	});
 
 	it('should reject an Object with an invalid identifier editor', () => {
-		expect(() => validateForm(
+		expect(() => validateEdition(
 			{
 				...validForm,
 				identifierEditor: INVALID_IDENTIFIERS
@@ -466,7 +466,7 @@ function describeValidateForm() {
 	});
 
 	it('should reject an Object with an invalid name section', () => {
-		expect(() => validateForm(
+		expect(() => validateEdition(
 			{
 				...validForm,
 				nameSection: INVALID_NAME_SECTION
@@ -476,7 +476,7 @@ function describeValidateForm() {
 	});
 
 	it('should reject an Object with an invalid edition section', () => {
-		expect(() => validateForm(
+		expect(() => validateEdition(
 			{
 				...validForm,
 				editionSection: INVALID_EDITION_SECTION
@@ -486,7 +486,7 @@ function describeValidateForm() {
 	});
 
 	it('should pass an Object with an empty submission section', () => {
-		expect(() => validateForm(
+		expect(() => validateEdition(
 			{
 				...validForm,
 				submissionSection: EMPTY_SUBMISSION_SECTION
@@ -501,18 +501,18 @@ function describeValidateForm() {
 	};
 
 	it('should reject an invalid Immutable.Map', () => {
-		expect(() => validateForm(
+		expect(() => validateEdition(
 			Immutable.fromJS(invalidForm),
 			IDENTIFIER_TYPES
 		)).to.throw(ValidationError);
 	});
 
 	it('should reject any other non-null data type', () => {
-		expect(() => validateForm(1, IDENTIFIER_TYPES)).to.throw(ValidationError);
+		expect(() => validateEdition(1, IDENTIFIER_TYPES)).to.throw(ValidationError);
 	});
 
 	it('should reject a null value', () => {
-		expect(() => validateForm(null, IDENTIFIER_TYPES)).to.throw(ValidationError);
+		expect(() => validateEdition(null, IDENTIFIER_TYPES)).to.throw(ValidationError);
 	});
 }
 

--- a/test/validators/test-identifier.js
+++ b/test/validators/test-identifier.js
@@ -1,0 +1,229 @@
+/*
+ * Copyright (C) 2017  Ben Ockmore
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+import * as Immutable from 'immutable';
+import {
+	IDENTIFIER_TYPES, INVALID_IDENTIFIER, INVALID_IDENTIFIERS, VALID_IDENTIFIER,
+	VALID_IDENTIFIERS
+} from './data';
+import {
+	testValidatePositiveIntegerFunc, testValidateStringFunc
+} from './helpers';
+import {
+	validateIdentifier, validateIdentifierType, validateIdentifierValue,
+	validateIdentifiers
+} from '../../lib/validators/common';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+
+
+chai.use(chaiAsPromised);
+const {expect} = chai;
+
+
+function describeValidateIdentifierValueNoIdentifierTypes() {
+	testValidateStringFunc(validateIdentifierValue);
+}
+
+function describeValidateIdentifierValueWithIdentifierTypes() {
+	it('should pass a non-empty string value that matches the validation regular expression', () => {
+		const result = validateIdentifierValue(
+			'B076KQRJV1', 1, IDENTIFIER_TYPES
+		);
+		expect(result).to.be.true;
+	});
+
+	it('should reject a non-empty string value that doesn\'t match the validation regular expression', () => {
+		const result = validateIdentifierValue('B076K1', 1, IDENTIFIER_TYPES);
+		expect(result).to.be.false;
+	});
+
+	it('should reject an empty string', () => {
+		const result = validateIdentifierValue('', 1, IDENTIFIER_TYPES);
+		expect(result).to.be.false;
+	});
+
+	it('should reject any non-string value', () => {
+		const result = validateIdentifierValue({}, 1, IDENTIFIER_TYPES);
+		expect(result).to.be.false;
+	});
+
+	it('should reject a null value', () => {
+		const result = validateIdentifierValue(null, 1, IDENTIFIER_TYPES);
+		expect(result).to.be.false;
+	});
+}
+
+function describeValidateIdentifierTypeNoIdentifierTypes() {
+	testValidatePositiveIntegerFunc(validateIdentifierType);
+}
+
+function describeValidateIdentifierTypeWithIdentifierTypes() {
+	it('should pass any positive integer value which is a type ID', () => {
+		const result = validateIdentifierType(1, IDENTIFIER_TYPES);
+		expect(result).to.be.true;
+	});
+
+	it('should reject any positive integer value which isn\'t a type ID', () => {
+		const result = validateIdentifierType(1000, IDENTIFIER_TYPES);
+		expect(result).to.be.false;
+	});
+
+	it('should reject zero', () => {
+		const result = validateIdentifierType(0, IDENTIFIER_TYPES);
+		expect(result).to.be.false;
+	});
+
+	it('should reject an negative number', () => {
+		const result = validateIdentifierType(-1, IDENTIFIER_TYPES);
+		expect(result).to.be.false;
+	});
+
+	it('should reject any non-number value', () => {
+		const result = validateIdentifierType({}, IDENTIFIER_TYPES);
+		expect(result).to.be.false;
+	});
+
+	it('should reject a null value', () => {
+		const result = validateIdentifierType(null, IDENTIFIER_TYPES);
+		expect(result).to.be.false;
+	});
+}
+
+function describeValidateIdentifier() {
+	it('should pass a valid Object', () => {
+		const result = validateIdentifier(VALID_IDENTIFIER, IDENTIFIER_TYPES);
+		expect(result).to.be.true;
+	});
+
+	it('should pass a valid Immutable.Map', () => {
+		const result = validateIdentifier(
+			Immutable.fromJS(VALID_IDENTIFIER), IDENTIFIER_TYPES
+		);
+		expect(result).to.be.true;
+	});
+
+	it('should reject an Object with an invalid value', () => {
+		const result = validateIdentifier(
+			{...VALID_IDENTIFIER, value: 'B076QRJV1'}, IDENTIFIER_TYPES
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid type', () => {
+		const result = validateIdentifier(
+			{...VALID_IDENTIFIER, type: 5},
+			IDENTIFIER_TYPES
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should reject an invalid Immutable.Map', () => {
+		const result = validateIdentifier(
+			Immutable.fromJS(INVALID_IDENTIFIER),
+			IDENTIFIER_TYPES
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should reject any other non-null data type', () => {
+		const result = validateIdentifier(1, IDENTIFIER_TYPES);
+		expect(result).to.be.false;
+	});
+
+	it('should reject a null value', () => {
+		const result = validateIdentifier(null, IDENTIFIER_TYPES);
+		expect(result).to.be.false;
+	});
+}
+
+
+function describeValidateIdentifiers() {
+	it('should pass an Object of two valid Objects', () => {
+		const result = validateIdentifiers(VALID_IDENTIFIERS, IDENTIFIER_TYPES);
+		expect(result).to.be.true;
+	});
+
+	it('should pass an Immutable.Map of valid Immutable.Maps', () => {
+		const result = validateIdentifiers(
+			Immutable.fromJS(VALID_IDENTIFIERS),
+			IDENTIFIER_TYPES
+		);
+		expect(result).to.be.true;
+	});
+
+	it('should pass an empty Object', () => {
+		const result = validateIdentifiers({}, IDENTIFIER_TYPES);
+		expect(result).to.be.true;
+	});
+
+	it('should pass an empty Immutable.Map', () => {
+		const result = validateIdentifiers(Immutable.Map(), IDENTIFIER_TYPES);
+		expect(result).to.be.true;
+	});
+
+	it('should reject an Object containing one invalid Object', () => {
+		const result = validateIdentifiers(
+			INVALID_IDENTIFIERS,
+			IDENTIFIER_TYPES
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Immutable.Map containing one invalid Immutable.Map', () => {
+		const result = validateIdentifiers(
+			Immutable.fromJS(INVALID_IDENTIFIERS),
+			IDENTIFIER_TYPES
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should reject any other non-null data type', () => {
+		const result = validateIdentifiers(1, IDENTIFIER_TYPES);
+		expect(result).to.be.false;
+	});
+
+	it('should reject a null value', () => {
+		const result = validateIdentifiers(null, IDENTIFIER_TYPES);
+		expect(result).to.be.false;
+	});
+}
+
+
+function tests() {
+	describe(
+		'validateIdentifierValue with no type set',
+		describeValidateIdentifierValueNoIdentifierTypes
+	);
+	describe(
+		'validateIdentifierValue with type set',
+		describeValidateIdentifierValueWithIdentifierTypes
+	);
+	describe(
+		'validateIdentifierType with no type set',
+		describeValidateIdentifierTypeNoIdentifierTypes
+	);
+	describe(
+		'validateIdentifierType with type set',
+		describeValidateIdentifierTypeWithIdentifierTypes
+	);
+	describe('validateIdentifier', describeValidateIdentifier);
+	describe('validateIdentifiers', describeValidateIdentifiers);
+}
+
+describe('validateIdentifier* functions', tests);

--- a/test/validators/test-identifier.js
+++ b/test/validators/test-identifier.js
@@ -28,6 +28,7 @@ import {
 	validateIdentifier, validateIdentifierType, validateIdentifierValue,
 	validateIdentifiers
 } from '../../lib/validators/common';
+import {ValidationError} from '../../lib/validators/base';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 
@@ -42,30 +43,25 @@ function describeValidateIdentifierValueNoIdentifierTypes() {
 
 function describeValidateIdentifierValueWithIdentifierTypes() {
 	it('should pass a non-empty string value that matches the validation regular expression', () => {
-		const result = validateIdentifierValue(
+		expect(() => validateIdentifierValue(
 			'B076KQRJV1', 1, IDENTIFIER_TYPES
-		);
-		expect(result).to.be.true;
+		)).to.not.throw();
 	});
 
 	it('should reject a non-empty string value that doesn\'t match the validation regular expression', () => {
-		const result = validateIdentifierValue('B076K1', 1, IDENTIFIER_TYPES);
-		expect(result).to.be.false;
+		expect(() => validateIdentifierValue('B076K1', 1, IDENTIFIER_TYPES)).to.throw(ValidationError);
 	});
 
 	it('should reject an empty string', () => {
-		const result = validateIdentifierValue('', 1, IDENTIFIER_TYPES);
-		expect(result).to.be.false;
+		expect(() => validateIdentifierValue('', 1, IDENTIFIER_TYPES)).to.throw(ValidationError);
 	});
 
 	it('should reject any non-string value', () => {
-		const result = validateIdentifierValue({}, 1, IDENTIFIER_TYPES);
-		expect(result).to.be.false;
+		expect(() => validateIdentifierValue({}, 1, IDENTIFIER_TYPES)).to.throw(ValidationError);
 	});
 
 	it('should reject a null value', () => {
-		const result = validateIdentifierValue(null, 1, IDENTIFIER_TYPES);
-		expect(result).to.be.false;
+		expect(() => validateIdentifierValue(null, 1, IDENTIFIER_TYPES)).to.throw(ValidationError);
 	});
 }
 
@@ -75,132 +71,111 @@ function describeValidateIdentifierTypeNoIdentifierTypes() {
 
 function describeValidateIdentifierTypeWithIdentifierTypes() {
 	it('should pass any positive integer value which is a type ID', () => {
-		const result = validateIdentifierType(1, IDENTIFIER_TYPES);
-		expect(result).to.be.true;
+		expect(() => validateIdentifierType(1, IDENTIFIER_TYPES)).to.not.throw();
 	});
 
 	it('should reject any positive integer value which isn\'t a type ID', () => {
-		const result = validateIdentifierType(1000, IDENTIFIER_TYPES);
-		expect(result).to.be.false;
+		expect(() => validateIdentifierType(1000, IDENTIFIER_TYPES)).to.throw(ValidationError);
 	});
 
 	it('should reject zero', () => {
-		const result = validateIdentifierType(0, IDENTIFIER_TYPES);
-		expect(result).to.be.false;
+		expect(() => validateIdentifierType(0, IDENTIFIER_TYPES)).to.throw(ValidationError);
 	});
 
 	it('should reject an negative number', () => {
-		const result = validateIdentifierType(-1, IDENTIFIER_TYPES);
-		expect(result).to.be.false;
+		expect(() => validateIdentifierType(-1, IDENTIFIER_TYPES)).to.throw(ValidationError);
 	});
 
 	it('should reject any non-number value', () => {
-		const result = validateIdentifierType({}, IDENTIFIER_TYPES);
-		expect(result).to.be.false;
+		expect(() => validateIdentifierType({}, IDENTIFIER_TYPES)).to.throw(ValidationError);
 	});
 
 	it('should reject a null value', () => {
-		const result = validateIdentifierType(null, IDENTIFIER_TYPES);
-		expect(result).to.be.false;
+		expect(() => validateIdentifierType(null, IDENTIFIER_TYPES)).to.throw(ValidationError);
 	});
 }
 
 function describeValidateIdentifier() {
 	it('should pass a valid Object', () => {
-		const result = validateIdentifier(VALID_IDENTIFIER, IDENTIFIER_TYPES);
-		expect(result).to.be.true;
+		expect(() => validateIdentifier(VALID_IDENTIFIER, IDENTIFIER_TYPES)).to.not.throw();
 	});
 
 	it('should pass a valid Immutable.Map', () => {
-		const result = validateIdentifier(
+		expect(() => validateIdentifier(
 			Immutable.fromJS(VALID_IDENTIFIER), IDENTIFIER_TYPES
-		);
-		expect(result).to.be.true;
+		)).to.not.throw();
 	});
 
 	it('should reject an Object with an invalid value', () => {
-		const result = validateIdentifier(
+		expect(() => validateIdentifier(
 			{...VALID_IDENTIFIER, value: 'B076QRJV1'}, IDENTIFIER_TYPES
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid type', () => {
-		const result = validateIdentifier(
+		expect(() => validateIdentifier(
 			{...VALID_IDENTIFIER, type: 5},
 			IDENTIFIER_TYPES
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should reject an invalid Immutable.Map', () => {
-		const result = validateIdentifier(
+		expect(() => validateIdentifier(
 			Immutable.fromJS(INVALID_IDENTIFIER),
 			IDENTIFIER_TYPES
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should reject any other non-null data type', () => {
-		const result = validateIdentifier(1, IDENTIFIER_TYPES);
-		expect(result).to.be.false;
+		expect(() => validateIdentifier(1, IDENTIFIER_TYPES)).to.throw(ValidationError);
 	});
 
 	it('should reject a null value', () => {
-		const result = validateIdentifier(null, IDENTIFIER_TYPES);
-		expect(result).to.be.false;
+		expect(() => validateIdentifier(null, IDENTIFIER_TYPES)).to.throw(ValidationError);
 	});
 }
 
 
 function describeValidateIdentifiers() {
 	it('should pass an Object of two valid Objects', () => {
-		const result = validateIdentifiers(VALID_IDENTIFIERS, IDENTIFIER_TYPES);
-		expect(result).to.be.true;
+		expect(() => validateIdentifiers(VALID_IDENTIFIERS, IDENTIFIER_TYPES)).to.not.throw();
 	});
 
 	it('should pass an Immutable.Map of valid Immutable.Maps', () => {
-		const result = validateIdentifiers(
+		expect(() => validateIdentifiers(
 			Immutable.fromJS(VALID_IDENTIFIERS),
 			IDENTIFIER_TYPES
-		);
-		expect(result).to.be.true;
+		)).to.not.throw();
 	});
 
 	it('should pass an empty Object', () => {
-		const result = validateIdentifiers({}, IDENTIFIER_TYPES);
-		expect(result).to.be.true;
+		expect(() => validateIdentifiers({}, IDENTIFIER_TYPES)).to.not.throw();
 	});
 
 	it('should pass an empty Immutable.Map', () => {
-		const result = validateIdentifiers(Immutable.Map(), IDENTIFIER_TYPES);
-		expect(result).to.be.true;
+		expect(() => validateIdentifiers(Immutable.Map(), IDENTIFIER_TYPES)).to.not.throw();
 	});
 
 	it('should reject an Object containing one invalid Object', () => {
-		const result = validateIdentifiers(
+		expect(() => validateIdentifiers(
 			INVALID_IDENTIFIERS,
 			IDENTIFIER_TYPES
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should reject an Immutable.Map containing one invalid Immutable.Map', () => {
-		const result = validateIdentifiers(
+		expect(() => validateIdentifiers(
 			Immutable.fromJS(INVALID_IDENTIFIERS),
 			IDENTIFIER_TYPES
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should reject any other non-null data type', () => {
-		const result = validateIdentifiers(1, IDENTIFIER_TYPES);
-		expect(result).to.be.false;
+		expect(() => validateIdentifiers(1, IDENTIFIER_TYPES)).to.throw(ValidationError);
 	});
 
 	it('should reject a null value', () => {
-		const result = validateIdentifiers(null, IDENTIFIER_TYPES);
-		expect(result).to.be.false;
+		expect(() => validateIdentifiers(null, IDENTIFIER_TYPES)).to.throw(ValidationError);
 	});
 }
 

--- a/test/validators/test-name-section.js
+++ b/test/validators/test-name-section.js
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2017  Ben Ockmore
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+import * as Immutable from 'immutable';
+import {INVALID_NAME_SECTION, VALID_NAME_SECTION} from './data';
+import {
+	testValidatePositiveIntegerFunc, testValidateStringFunc
+} from './helpers';
+import {
+	validateNameSection, validateNameSectionDisambiguation,
+	validateNameSectionLanguage, validateNameSectionName,
+	validateNameSectionSortName
+} from '../../lib/validators/common';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+
+
+chai.use(chaiAsPromised);
+const {expect} = chai;
+
+
+function describeValidateNameSectionName() {
+	testValidateStringFunc(validateNameSectionName);
+}
+
+function describeValidateNameSectionSortName() {
+	testValidateStringFunc(validateNameSectionSortName);
+}
+
+function describeValidateNameSectionLanguage() {
+	testValidatePositiveIntegerFunc(validateNameSectionLanguage);
+}
+
+function describeValidateNameSectionDisambiguation() {
+	testValidateStringFunc(validateNameSectionDisambiguation, false);
+}
+
+
+function describeValidateNameSection() {
+	it('should pass a valid Object', () => {
+		const result = validateNameSection(VALID_NAME_SECTION);
+		expect(result).to.be.true;
+	});
+
+	it('should pass a valid Immutable.Map', () => {
+		const result = validateNameSection(
+			Immutable.fromJS(VALID_NAME_SECTION)
+		);
+		expect(result).to.be.true;
+	});
+
+	it('should reject an Object with an invalid name', () => {
+		const result = validateNameSection({...VALID_NAME_SECTION, name: null});
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid sort name', () => {
+		const result = validateNameSection(
+			{...VALID_NAME_SECTION, sortName: null}
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid language', () => {
+		const result = validateNameSection(
+			{...VALID_NAME_SECTION, language: null}
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid disambiguation', () => {
+		const result = validateNameSection(
+			{...VALID_NAME_SECTION, disambiguation: 2}
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should reject an invalid Immutable.Map', () => {
+		const result = validateNameSection(
+			Immutable.fromJS(INVALID_NAME_SECTION)
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should reject any other non-null data type', () => {
+		const result = validateNameSection(1);
+		expect(result).to.be.false;
+	});
+
+	it('should reject a null value', () => {
+		const result = validateNameSection(null);
+		expect(result).to.be.false;
+	});
+}
+
+
+function tests() {
+	describe('validateNameSectionName', describeValidateNameSectionName);
+	describe(
+		'validateNameSectionSortName',
+		describeValidateNameSectionSortName
+	);
+	describe(
+		'validateNameSectionLanguage',
+		describeValidateNameSectionLanguage
+	);
+	describe(
+		'validateNameSectionDisambiguation',
+		describeValidateNameSectionDisambiguation
+	);
+	describe('validateNameSection', describeValidateNameSection);
+}
+
+describe('validateNameSection* functions', tests);

--- a/test/validators/test-name-section.js
+++ b/test/validators/test-name-section.js
@@ -26,6 +26,7 @@ import {
 	validateNameSectionLanguage, validateNameSectionName,
 	validateNameSectionSortName
 } from '../../lib/validators/common';
+import {ValidationError} from '../../lib/validators/base';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 
@@ -53,58 +54,49 @@ function describeValidateNameSectionDisambiguation() {
 
 function describeValidateNameSection() {
 	it('should pass a valid Object', () => {
-		const result = validateNameSection(VALID_NAME_SECTION);
-		expect(result).to.be.true;
+		expect(() => validateNameSection(VALID_NAME_SECTION)).to.not.throw();
 	});
 
 	it('should pass a valid Immutable.Map', () => {
-		const result = validateNameSection(
+		expect(() => validateNameSection(
 			Immutable.fromJS(VALID_NAME_SECTION)
-		);
-		expect(result).to.be.true;
+		)).to.not.throw();
 	});
 
 	it('should reject an Object with an invalid name', () => {
-		const result = validateNameSection({...VALID_NAME_SECTION, name: null});
-		expect(result).to.be.false;
+		expect(() => validateNameSection({...VALID_NAME_SECTION, name: null})).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid sort name', () => {
-		const result = validateNameSection(
+		expect(() => validateNameSection(
 			{...VALID_NAME_SECTION, sortName: null}
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid language', () => {
-		const result = validateNameSection(
+		expect(() => validateNameSection(
 			{...VALID_NAME_SECTION, language: null}
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid disambiguation', () => {
-		const result = validateNameSection(
+		expect(() => validateNameSection(
 			{...VALID_NAME_SECTION, disambiguation: 2}
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should reject an invalid Immutable.Map', () => {
-		const result = validateNameSection(
+		expect(() => validateNameSection(
 			Immutable.fromJS(INVALID_NAME_SECTION)
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should reject any other non-null data type', () => {
-		const result = validateNameSection(1);
-		expect(result).to.be.false;
+		expect(() => validateNameSection(1)).to.throw(ValidationError);
 	});
 
 	it('should reject a null value', () => {
-		const result = validateNameSection(null);
-		expect(result).to.be.false;
+		expect(() => validateNameSection(null)).to.throw(ValidationError);
 	});
 }
 

--- a/test/validators/test-publisher.js
+++ b/test/validators/test-publisher.js
@@ -46,6 +46,7 @@ import {
 	validatePublisherSectionType
 } from '../../lib/validators/publisher';
 
+import {ValidationError} from '../../lib/validators/base';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 
@@ -85,72 +86,62 @@ const INVALID_PUBLISHER_SECTION = {...VALID_PUBLISHER_SECTION, type: {}};
 
 function describeValidatePublisherSection() {
 	it('should pass a valid Object', () => {
-		const result = validatePublisherSection(VALID_PUBLISHER_SECTION);
-		expect(result).to.be.true;
+		expect(() => validatePublisherSection(VALID_PUBLISHER_SECTION)).to.not.throw();
 	});
 
 	it('should pass a valid Immutable.Map', () => {
-		const result = validatePublisherSection(
+		expect(() => validatePublisherSection(
 			Immutable.fromJS(VALID_PUBLISHER_SECTION)
-		);
-		expect(result).to.be.true;
+		)).to.not.throw();
 	});
 
 	it('should reject an Object with an invalid area', () => {
-		const result = validatePublisherSection({
+		expect(() => validatePublisherSection({
 			...VALID_PUBLISHER_SECTION,
 			area: {id: null}
-		});
-		expect(result).to.be.false;
+		})).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid begin date', () => {
-		const result = validatePublisherSection({
+		expect(() => validatePublisherSection({
 			...VALID_PUBLISHER_SECTION,
 			beginDate: {day: '', month: '19', year: '2019'}
-		});
-		expect(result).to.be.false;
+		})).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid end date', () => {
-		const result = validatePublisherSection({
+		expect(() => validatePublisherSection({
 			...VALID_PUBLISHER_SECTION,
 			endDate: {day: '', month: '19', year: '2019'}
-		});
-		expect(result).to.be.false;
+		})).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid ended flag', () => {
-		const result = validatePublisherSection({
+		expect(() => validatePublisherSection({
 			...VALID_PUBLISHER_SECTION,
 			ended: 1
-		});
-		expect(result).to.be.false;
+		})).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid type', () => {
-		const result = validatePublisherSection({
+		expect(() => validatePublisherSection({
 			...VALID_PUBLISHER_SECTION,
 			type: {}
-		});
-		expect(result).to.be.false;
+		})).to.throw(ValidationError);
 	});
 
 	it('should reject an invalid Immutable.Map', () => {
-		const result = validatePublisherSection(
+		expect(() => validatePublisherSection(
 			Immutable.fromJS(INVALID_PUBLISHER_SECTION)
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should pass any other non-null data type', () => {
-		const result = validatePublisherSection(1);
-		expect(result).to.be.true;
+		expect(() => validatePublisherSection(1)).to.not.throw();
 	});
 
 	it('should pass a null value', () => {
-		const result = validatePublisherSection({});
-		expect(result).to.be.true;
+		expect(() => validatePublisherSection({})).to.not.throw();
 	});
 }
 
@@ -165,70 +156,63 @@ function describeValidateForm() {
 	};
 
 	it('should pass a valid Object', () => {
-		const result = validateForm(validForm, IDENTIFIER_TYPES);
-		expect(result).to.be.true;
+		expect(() => validateForm(validForm, IDENTIFIER_TYPES)).to.not.throw();
 	});
 
 	it('should pass a valid Immutable.Map', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			Immutable.fromJS(validForm),
 			IDENTIFIER_TYPES
-		);
-		expect(result).to.be.true;
+		)).to.not.throw();
 	});
 
 	it('should reject an Object with an invalid alias editor', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			{
 				...validForm,
 				aliasEditor: INVALID_ALIASES
 			},
 			IDENTIFIER_TYPES
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid identifier editor', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			{
 				...validForm,
 				identifierEditor: INVALID_IDENTIFIERS
 			}, IDENTIFIER_TYPES
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid name section', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			{
 				...validForm,
 				nameSection: INVALID_NAME_SECTION
 			},
 			IDENTIFIER_TYPES
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid publisher section', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			{
 				...validForm,
 				publisherSection: INVALID_PUBLISHER_SECTION
 			},
 			IDENTIFIER_TYPES
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should pass an Object with an empty submission section', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			{
 				...validForm,
 				submissionSection: EMPTY_SUBMISSION_SECTION
 			},
 			IDENTIFIER_TYPES
-		);
-		expect(result).to.be.true;
+		)).to.not.throw();
 	});
 
 	const invalidForm = {
@@ -237,21 +221,18 @@ function describeValidateForm() {
 	};
 
 	it('should reject an invalid Immutable.Map', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			Immutable.fromJS(invalidForm),
 			IDENTIFIER_TYPES
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should reject any other non-null data type', () => {
-		const result = validateForm(1, IDENTIFIER_TYPES);
-		expect(result).to.be.false;
+		expect(() => validateForm(1, IDENTIFIER_TYPES)).to.throw(ValidationError);
 	});
 
 	it('should reject a null value', () => {
-		const result = validateForm(null, IDENTIFIER_TYPES);
-		expect(result).to.be.false;
+		expect(() => validateForm(null, IDENTIFIER_TYPES)).to.throw(ValidationError);
 	});
 }
 

--- a/test/validators/test-publisher.js
+++ b/test/validators/test-publisher.js
@@ -1,0 +1,290 @@
+/*
+ * Copyright (C) 2017  Ben Ockmore
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+import * as Immutable from 'immutable';
+
+import {
+	EMPTY_SUBMISSION_SECTION,
+	IDENTIFIER_TYPES,
+	INVALID_ALIASES,
+	INVALID_IDENTIFIERS,
+	INVALID_NAME_SECTION,
+	VALID_ALIASES,
+	VALID_IDENTIFIERS,
+	VALID_NAME_SECTION,
+	VALID_SUBMISSION_SECTION
+} from './data';
+import {
+	testValidateAreaFunc,
+	testValidateBooleanFunc,
+	testValidateDateFunc,
+	testValidateEndDateFunc,
+	testValidatePositiveIntegerFunc
+} from './helpers';
+import {
+	validateForm,
+	validatePublisherSection,
+	validatePublisherSectionArea,
+	validatePublisherSectionBeginDate,
+	validatePublisherSectionEndDate,
+	validatePublisherSectionEnded,
+	validatePublisherSectionType
+} from '../../lib/validators/publisher';
+
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+
+
+chai.use(chaiAsPromised);
+const {expect} = chai;
+
+
+function describeValidatePublisherSectionArea() {
+	testValidateAreaFunc(validatePublisherSectionArea, false);
+}
+
+function describeValidatePublisherSectionBeginDate() {
+	testValidateDateFunc(validatePublisherSectionBeginDate, false);
+}
+
+function describeValidatePublisherSectionEndDate() {
+	testValidateEndDateFunc(validatePublisherSectionEndDate, false);
+}
+
+function describeValidatePublisherSectionEnded() {
+	testValidateBooleanFunc(validatePublisherSectionEnded, false);
+}
+
+function describeValidatePublisherSectionType() {
+	testValidatePositiveIntegerFunc(validatePublisherSectionType, false);
+}
+
+const VALID_PUBLISHER_SECTION = {
+	area: null,
+	beginDate: '',
+	endDate: '',
+	ended: true,
+	type: 1
+};
+const INVALID_PUBLISHER_SECTION = {...VALID_PUBLISHER_SECTION, type: {}};
+
+function describeValidatePublisherSection() {
+	it('should pass a valid Object', () => {
+		const result = validatePublisherSection(VALID_PUBLISHER_SECTION);
+		expect(result).to.be.true;
+	});
+
+	it('should pass a valid Immutable.Map', () => {
+		const result = validatePublisherSection(
+			Immutable.fromJS(VALID_PUBLISHER_SECTION)
+		);
+		expect(result).to.be.true;
+	});
+
+	it('should reject an Object with an invalid area', () => {
+		const result = validatePublisherSection({
+			...VALID_PUBLISHER_SECTION,
+			area: {id: null}
+		});
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid begin date', () => {
+		const result = validatePublisherSection({
+			...VALID_PUBLISHER_SECTION,
+			beginDate: {day: '', month: '19', year: '2019'}
+		});
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid end date', () => {
+		const result = validatePublisherSection({
+			...VALID_PUBLISHER_SECTION,
+			endDate: {day: '', month: '19', year: '2019'}
+		});
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid ended flag', () => {
+		const result = validatePublisherSection({
+			...VALID_PUBLISHER_SECTION,
+			ended: 1
+		});
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid type', () => {
+		const result = validatePublisherSection({
+			...VALID_PUBLISHER_SECTION,
+			type: {}
+		});
+		expect(result).to.be.false;
+	});
+
+	it('should reject an invalid Immutable.Map', () => {
+		const result = validatePublisherSection(
+			Immutable.fromJS(INVALID_PUBLISHER_SECTION)
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should pass any other non-null data type', () => {
+		const result = validatePublisherSection(1);
+		expect(result).to.be.true;
+	});
+
+	it('should pass a null value', () => {
+		const result = validatePublisherSection({});
+		expect(result).to.be.true;
+	});
+}
+
+
+function describeValidateForm() {
+	const validForm = {
+		aliasEditor: VALID_ALIASES,
+		identifierEditor: VALID_IDENTIFIERS,
+		nameSection: VALID_NAME_SECTION,
+		publisherSection: VALID_PUBLISHER_SECTION,
+		submissionSection: VALID_SUBMISSION_SECTION
+	};
+
+	it('should pass a valid Object', () => {
+		const result = validateForm(validForm, IDENTIFIER_TYPES);
+		expect(result).to.be.true;
+	});
+
+	it('should pass a valid Immutable.Map', () => {
+		const result = validateForm(
+			Immutable.fromJS(validForm),
+			IDENTIFIER_TYPES
+		);
+		expect(result).to.be.true;
+	});
+
+	it('should reject an Object with an invalid alias editor', () => {
+		const result = validateForm(
+			{
+				...validForm,
+				aliasEditor: INVALID_ALIASES
+			},
+			IDENTIFIER_TYPES
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid identifier editor', () => {
+		const result = validateForm(
+			{
+				...validForm,
+				identifierEditor: INVALID_IDENTIFIERS
+			}, IDENTIFIER_TYPES
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid name section', () => {
+		const result = validateForm(
+			{
+				...validForm,
+				nameSection: INVALID_NAME_SECTION
+			},
+			IDENTIFIER_TYPES
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid publisher section', () => {
+		const result = validateForm(
+			{
+				...validForm,
+				publisherSection: INVALID_PUBLISHER_SECTION
+			},
+			IDENTIFIER_TYPES
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should pass an Object with an empty submission section', () => {
+		const result = validateForm(
+			{
+				...validForm,
+				submissionSection: EMPTY_SUBMISSION_SECTION
+			},
+			IDENTIFIER_TYPES
+		);
+		expect(result).to.be.true;
+	});
+
+	const invalidForm = {
+		...validForm,
+		nameSection: INVALID_NAME_SECTION
+	};
+
+	it('should reject an invalid Immutable.Map', () => {
+		const result = validateForm(
+			Immutable.fromJS(invalidForm),
+			IDENTIFIER_TYPES
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should reject any other non-null data type', () => {
+		const result = validateForm(1, IDENTIFIER_TYPES);
+		expect(result).to.be.false;
+	});
+
+	it('should reject a null value', () => {
+		const result = validateForm(null, IDENTIFIER_TYPES);
+		expect(result).to.be.false;
+	});
+}
+
+
+function tests() {
+	describe(
+		'validatePublisherSectionArea',
+		describeValidatePublisherSectionArea
+	);
+	describe(
+		'validatePublisherSectionBeginDate',
+		describeValidatePublisherSectionBeginDate
+	);
+	describe(
+		'validatePublisherSectionEndDate',
+		describeValidatePublisherSectionEndDate
+	);
+	describe(
+		'validatePublisherSectionEnded',
+		describeValidatePublisherSectionEnded
+	);
+	describe(
+		'validatePublisherSectionType',
+		describeValidatePublisherSectionType
+	);
+	describe(
+		'validatePublisherSection',
+		describeValidatePublisherSection
+	);
+	describe(
+		'validateForm',
+		describeValidateForm
+	);
+}
+
+describe('validatePublisherSection* functions', tests);

--- a/test/validators/test-publisher.js
+++ b/test/validators/test-publisher.js
@@ -37,7 +37,7 @@ import {
 	testValidatePositiveIntegerFunc
 } from './helpers';
 import {
-	validateForm,
+	validatePublisher,
 	validatePublisherSection,
 	validatePublisherSectionArea,
 	validatePublisherSectionBeginDate,
@@ -156,18 +156,18 @@ function describeValidateForm() {
 	};
 
 	it('should pass a valid Object', () => {
-		expect(() => validateForm(validForm, IDENTIFIER_TYPES)).to.not.throw();
+		expect(() => validatePublisher(validForm, IDENTIFIER_TYPES)).to.not.throw();
 	});
 
 	it('should pass a valid Immutable.Map', () => {
-		expect(() => validateForm(
+		expect(() => validatePublisher(
 			Immutable.fromJS(validForm),
 			IDENTIFIER_TYPES
 		)).to.not.throw();
 	});
 
 	it('should reject an Object with an invalid alias editor', () => {
-		expect(() => validateForm(
+		expect(() => validatePublisher(
 			{
 				...validForm,
 				aliasEditor: INVALID_ALIASES
@@ -177,7 +177,7 @@ function describeValidateForm() {
 	});
 
 	it('should reject an Object with an invalid identifier editor', () => {
-		expect(() => validateForm(
+		expect(() => validatePublisher(
 			{
 				...validForm,
 				identifierEditor: INVALID_IDENTIFIERS
@@ -186,7 +186,7 @@ function describeValidateForm() {
 	});
 
 	it('should reject an Object with an invalid name section', () => {
-		expect(() => validateForm(
+		expect(() => validatePublisher(
 			{
 				...validForm,
 				nameSection: INVALID_NAME_SECTION
@@ -196,7 +196,7 @@ function describeValidateForm() {
 	});
 
 	it('should reject an Object with an invalid publisher section', () => {
-		expect(() => validateForm(
+		expect(() => validatePublisher(
 			{
 				...validForm,
 				publisherSection: INVALID_PUBLISHER_SECTION
@@ -206,7 +206,7 @@ function describeValidateForm() {
 	});
 
 	it('should pass an Object with an empty submission section', () => {
-		expect(() => validateForm(
+		expect(() => validatePublisher(
 			{
 				...validForm,
 				submissionSection: EMPTY_SUBMISSION_SECTION
@@ -221,18 +221,18 @@ function describeValidateForm() {
 	};
 
 	it('should reject an invalid Immutable.Map', () => {
-		expect(() => validateForm(
+		expect(() => validatePublisher(
 			Immutable.fromJS(invalidForm),
 			IDENTIFIER_TYPES
 		)).to.throw(ValidationError);
 	});
 
 	it('should reject any other non-null data type', () => {
-		expect(() => validateForm(1, IDENTIFIER_TYPES)).to.throw(ValidationError);
+		expect(() => validatePublisher(1, IDENTIFIER_TYPES)).to.throw(ValidationError);
 	});
 
 	it('should reject a null value', () => {
-		expect(() => validateForm(null, IDENTIFIER_TYPES)).to.throw(ValidationError);
+		expect(() => validatePublisher(null, IDENTIFIER_TYPES)).to.throw(ValidationError);
 	});
 }
 

--- a/test/validators/test-series.js
+++ b/test/validators/test-series.js
@@ -36,6 +36,7 @@ import {
 	validateSeriesSectionOrderingType
 } from '../../lib/validators/series';
 
+import {ValidationError} from '../../lib/validators/base';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import {testValidatePositiveIntegerFunc} from './helpers';
@@ -54,12 +55,10 @@ function describeValidateSeriesSectionOrderingType() {
 
 function describeValidateSeriesSectionEntityType() {
 	it('should return true if passed a valid series type', () => {
-		const result = validateSeriesSectionEntityType(VALID_SERIES_TYPE);
-		expect(result).to.be.true;
+		expect(() => validateSeriesSectionEntityType(VALID_SERIES_TYPE)).to.not.throw();
 	});
 	it('should return false if passed a invalid series type', () => {
-		const result = validateSeriesSectionEntityType(INVALID_SERIES_TYPE);
-		expect(result).to.be.false;
+		expect(() => validateSeriesSectionEntityType(INVALID_SERIES_TYPE)).to.throw(ValidationError);
 	});
 }
 
@@ -71,48 +70,41 @@ const INVALID_SERIES_SECTION = {...VALID_SERIES_SECTION, seriesType: INVALID_SER
 
 function describeValidateSeriesSection() {
 	it('should pass a valid Object', () => {
-		const result = validateSeriesSection(VALID_SERIES_SECTION);
-		expect(result).to.be.true;
+		expect(() => validateSeriesSection(VALID_SERIES_SECTION)).to.not.throw();
 	});
 
 	it('should pass a valid Immutable.Map', () => {
-		const result = validateSeriesSection(
+		expect(() => validateSeriesSection(
 			Immutable.fromJS(VALID_SERIES_SECTION)
-		);
-		expect(result).to.be.true;
+		)).to.not.throw();
 	});
 
 	it('should reject an Object with an invalid ordering type', () => {
-		const result = validateSeriesSection({
+		expect(() => validateSeriesSection({
 			...VALID_SERIES_SECTION,
 			orderType: {}
-		});
-		expect(result).to.be.false;
+		})).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid series type', () => {
-		const result = validateSeriesSection({
+		expect(() => validateSeriesSection({
 			...VALID_SERIES_SECTION,
 			seriesType: INVALID_SERIES_TYPE
-		});
-		expect(result).to.be.false;
+		})).to.throw(ValidationError);
 	});
 
 	it('should reject an invalid Immutable.Map', () => {
-		const result = validateSeriesSection(
+		expect(() => validateSeriesSection(
 			Immutable.fromJS(INVALID_SERIES_SECTION)
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should reject any other non-null data type', () => {
-		const result = validateSeriesSection(1);
-		expect(result).to.be.false;
+		expect(() => validateSeriesSection(1)).to.throw(ValidationError);
 	});
 
 	it('should reject a null value', () => {
-		const result = validateSeriesSection(null);
-		expect(result).to.be.false;
+		expect(() => validateSeriesSection(null)).to.throw(ValidationError);
 	});
 }
 
@@ -126,70 +118,63 @@ function describeValidateForm() {
 	};
 
 	it('should pass a valid Object', () => {
-		const result = validateForm(validForm, IDENTIFIER_TYPES);
-		expect(result).to.be.true;
+		expect(() => validateForm(validForm, IDENTIFIER_TYPES)).to.not.throw();
 	});
 
 	it('should pass a valid Immutable.Map', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			Immutable.fromJS(validForm),
 			IDENTIFIER_TYPES
-		);
-		expect(result).to.be.true;
+		)).to.not.throw();
 	});
 
 	it('should reject an Object with an invalid alias editor', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			{
 				...validForm,
 				aliasEditor: INVALID_ALIASES
 			},
 			IDENTIFIER_TYPES
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid identifier editor', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			{
 				...validForm,
 				identifierEditor: INVALID_IDENTIFIERS
 			}, IDENTIFIER_TYPES
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid name section', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			{
 				...validForm,
 				nameSection: INVALID_NAME_SECTION
 			},
 			IDENTIFIER_TYPES
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid series section', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			{
 				...validForm,
 				seriesSection: INVALID_SERIES_SECTION
 			},
 			IDENTIFIER_TYPES
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should pass an Object with an empty submission section', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			{
 				...validForm,
 				submissionSection: EMPTY_SUBMISSION_SECTION
 			},
 			IDENTIFIER_TYPES
-		);
-		expect(result).to.be.true;
+		)).to.not.throw();
 	});
 
 	const invalidForm = {
@@ -198,21 +183,18 @@ function describeValidateForm() {
 	};
 
 	it('should reject an invalid Immutable.Map', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			Immutable.fromJS(invalidForm),
 			IDENTIFIER_TYPES
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should reject any other non-null data type', () => {
-		const result = validateForm(1, IDENTIFIER_TYPES);
-		expect(result).to.be.false;
+		expect(() => validateForm(1, IDENTIFIER_TYPES)).to.throw(ValidationError);
 	});
 
 	it('should reject a null value', () => {
-		const result = validateForm(null, IDENTIFIER_TYPES);
-		expect(result).to.be.false;
+		expect(() => validateForm(null, IDENTIFIER_TYPES)).to.throw(ValidationError);
 	});
 }
 

--- a/test/validators/test-series.js
+++ b/test/validators/test-series.js
@@ -1,0 +1,239 @@
+/*
+ * Copyright (C) 2021 Akash Gupta
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+import * as Immutable from 'immutable';
+
+import {
+	EMPTY_SUBMISSION_SECTION,
+	IDENTIFIER_TYPES,
+	INVALID_ALIASES,
+	INVALID_IDENTIFIERS,
+	INVALID_NAME_SECTION,
+	VALID_ALIASES,
+	VALID_IDENTIFIERS,
+	VALID_NAME_SECTION,
+	VALID_SUBMISSION_SECTION
+} from './data';
+import {
+	validateForm,
+	validateSeriesSection,
+	validateSeriesSectionEntityType,
+	validateSeriesSectionOrderingType
+} from '../../lib/validators/series';
+
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import {testValidatePositiveIntegerFunc} from './helpers';
+
+
+chai.use(chaiAsPromised);
+const {expect} = chai;
+
+
+const VALID_SERIES_TYPE = 'Author';
+const INVALID_SERIES_TYPE = 'XYZ';
+
+function describeValidateSeriesSectionOrderingType() {
+	testValidatePositiveIntegerFunc(validateSeriesSectionOrderingType, true);
+}
+
+function describeValidateSeriesSectionEntityType() {
+	it('should return true if passed a valid series type', () => {
+		const result = validateSeriesSectionEntityType(VALID_SERIES_TYPE);
+		expect(result).to.be.true;
+	});
+	it('should return false if passed a invalid series type', () => {
+		const result = validateSeriesSectionEntityType(INVALID_SERIES_TYPE);
+		expect(result).to.be.false;
+	});
+}
+
+const VALID_SERIES_SECTION = {
+	orderType: 1,
+	seriesType: VALID_SERIES_TYPE
+};
+const INVALID_SERIES_SECTION = {...VALID_SERIES_SECTION, seriesType: INVALID_SERIES_TYPE};
+
+function describeValidateSeriesSection() {
+	it('should pass a valid Object', () => {
+		const result = validateSeriesSection(VALID_SERIES_SECTION);
+		expect(result).to.be.true;
+	});
+
+	it('should pass a valid Immutable.Map', () => {
+		const result = validateSeriesSection(
+			Immutable.fromJS(VALID_SERIES_SECTION)
+		);
+		expect(result).to.be.true;
+	});
+
+	it('should reject an Object with an invalid ordering type', () => {
+		const result = validateSeriesSection({
+			...VALID_SERIES_SECTION,
+			orderType: {}
+		});
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid series type', () => {
+		const result = validateSeriesSection({
+			...VALID_SERIES_SECTION,
+			seriesType: INVALID_SERIES_TYPE
+		});
+		expect(result).to.be.false;
+	});
+
+	it('should reject an invalid Immutable.Map', () => {
+		const result = validateSeriesSection(
+			Immutable.fromJS(INVALID_SERIES_SECTION)
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should reject any other non-null data type', () => {
+		const result = validateSeriesSection(1);
+		expect(result).to.be.false;
+	});
+
+	it('should reject a null value', () => {
+		const result = validateSeriesSection(null);
+		expect(result).to.be.false;
+	});
+}
+
+function describeValidateForm() {
+	const validForm = {
+		aliasEditor: VALID_ALIASES,
+		identifierEditor: VALID_IDENTIFIERS,
+		nameSection: VALID_NAME_SECTION,
+		seriesSection: VALID_SERIES_SECTION,
+		submissionSection: VALID_SUBMISSION_SECTION
+	};
+
+	it('should pass a valid Object', () => {
+		const result = validateForm(validForm, IDENTIFIER_TYPES);
+		expect(result).to.be.true;
+	});
+
+	it('should pass a valid Immutable.Map', () => {
+		const result = validateForm(
+			Immutable.fromJS(validForm),
+			IDENTIFIER_TYPES
+		);
+		expect(result).to.be.true;
+	});
+
+	it('should reject an Object with an invalid alias editor', () => {
+		const result = validateForm(
+			{
+				...validForm,
+				aliasEditor: INVALID_ALIASES
+			},
+			IDENTIFIER_TYPES
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid identifier editor', () => {
+		const result = validateForm(
+			{
+				...validForm,
+				identifierEditor: INVALID_IDENTIFIERS
+			}, IDENTIFIER_TYPES
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid name section', () => {
+		const result = validateForm(
+			{
+				...validForm,
+				nameSection: INVALID_NAME_SECTION
+			},
+			IDENTIFIER_TYPES
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid series section', () => {
+		const result = validateForm(
+			{
+				...validForm,
+				seriesSection: INVALID_SERIES_SECTION
+			},
+			IDENTIFIER_TYPES
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should pass an Object with an empty submission section', () => {
+		const result = validateForm(
+			{
+				...validForm,
+				submissionSection: EMPTY_SUBMISSION_SECTION
+			},
+			IDENTIFIER_TYPES
+		);
+		expect(result).to.be.true;
+	});
+
+	const invalidForm = {
+		...validForm,
+		nameSection: INVALID_NAME_SECTION
+	};
+
+	it('should reject an invalid Immutable.Map', () => {
+		const result = validateForm(
+			Immutable.fromJS(invalidForm),
+			IDENTIFIER_TYPES
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should reject any other non-null data type', () => {
+		const result = validateForm(1, IDENTIFIER_TYPES);
+		expect(result).to.be.false;
+	});
+
+	it('should reject a null value', () => {
+		const result = validateForm(null, IDENTIFIER_TYPES);
+		expect(result).to.be.false;
+	});
+}
+
+
+function tests() {
+	describe(
+		'validateSeriesSectionOrderingType',
+		describeValidateSeriesSectionOrderingType
+	);
+	describe(
+		'validateSeriesSectionEntityType',
+		describeValidateSeriesSectionEntityType
+	);
+	describe(
+		'validateSeriesSection',
+		describeValidateSeriesSection
+	);
+	describe(
+		'validateForm',
+		describeValidateForm
+	);
+}
+
+describe('validateSeriesSection* functions', tests);

--- a/test/validators/test-series.js
+++ b/test/validators/test-series.js
@@ -30,7 +30,7 @@ import {
 	VALID_SUBMISSION_SECTION
 } from './data';
 import {
-	validateForm,
+	validateSeries,
 	validateSeriesSection,
 	validateSeriesSectionEntityType,
 	validateSeriesSectionOrderingType
@@ -118,18 +118,18 @@ function describeValidateForm() {
 	};
 
 	it('should pass a valid Object', () => {
-		expect(() => validateForm(validForm, IDENTIFIER_TYPES)).to.not.throw();
+		expect(() => validateSeries(validForm, IDENTIFIER_TYPES)).to.not.throw();
 	});
 
 	it('should pass a valid Immutable.Map', () => {
-		expect(() => validateForm(
+		expect(() => validateSeries(
 			Immutable.fromJS(validForm),
 			IDENTIFIER_TYPES
 		)).to.not.throw();
 	});
 
 	it('should reject an Object with an invalid alias editor', () => {
-		expect(() => validateForm(
+		expect(() => validateSeries(
 			{
 				...validForm,
 				aliasEditor: INVALID_ALIASES
@@ -139,7 +139,7 @@ function describeValidateForm() {
 	});
 
 	it('should reject an Object with an invalid identifier editor', () => {
-		expect(() => validateForm(
+		expect(() => validateSeries(
 			{
 				...validForm,
 				identifierEditor: INVALID_IDENTIFIERS
@@ -148,7 +148,7 @@ function describeValidateForm() {
 	});
 
 	it('should reject an Object with an invalid name section', () => {
-		expect(() => validateForm(
+		expect(() => validateSeries(
 			{
 				...validForm,
 				nameSection: INVALID_NAME_SECTION
@@ -158,7 +158,7 @@ function describeValidateForm() {
 	});
 
 	it('should reject an Object with an invalid series section', () => {
-		expect(() => validateForm(
+		expect(() => validateSeries(
 			{
 				...validForm,
 				seriesSection: INVALID_SERIES_SECTION
@@ -168,7 +168,7 @@ function describeValidateForm() {
 	});
 
 	it('should pass an Object with an empty submission section', () => {
-		expect(() => validateForm(
+		expect(() => validateSeries(
 			{
 				...validForm,
 				submissionSection: EMPTY_SUBMISSION_SECTION
@@ -183,18 +183,18 @@ function describeValidateForm() {
 	};
 
 	it('should reject an invalid Immutable.Map', () => {
-		expect(() => validateForm(
+		expect(() => validateSeries(
 			Immutable.fromJS(invalidForm),
 			IDENTIFIER_TYPES
 		)).to.throw(ValidationError);
 	});
 
 	it('should reject any other non-null data type', () => {
-		expect(() => validateForm(1, IDENTIFIER_TYPES)).to.throw(ValidationError);
+		expect(() => validateSeries(1, IDENTIFIER_TYPES)).to.throw(ValidationError);
 	});
 
 	it('should reject a null value', () => {
-		expect(() => validateForm(null, IDENTIFIER_TYPES)).to.throw(ValidationError);
+		expect(() => validateSeries(null, IDENTIFIER_TYPES)).to.throw(ValidationError);
 	});
 }
 

--- a/test/validators/test-submission-section.js
+++ b/test/validators/test-submission-section.js
@@ -24,6 +24,7 @@ import {
 	validateSubmissionSectionNote
 } from '../../lib/validators/common';
 
+import {ValidationError} from '../../lib/validators/base';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import {testValidateStringFunc} from './helpers';
@@ -40,41 +41,35 @@ function describeValidateSubmissionSectionNote() {
 
 function describeValidateSubmissionSection() {
 	it('should pass a valid Object', () => {
-		const result = validateSubmissionSection(VALID_SUBMISSION_SECTION);
-		expect(result).to.be.true;
+		expect(() => validateSubmissionSection(VALID_SUBMISSION_SECTION)).to.not.throw();
 	});
 
 	it('should pass a valid Immutable.Map', () => {
-		const result = validateSubmissionSection(
+		expect(() => validateSubmissionSection(
 			Immutable.fromJS(VALID_SUBMISSION_SECTION)
-		);
-		expect(result).to.be.true;
+		)).to.not.throw();
 	});
 
 	it('should pass an Object with an empty note', () => {
-		const result = validateSubmissionSection(
+		expect(() => validateSubmissionSection(
 			{...VALID_SUBMISSION_SECTION, note: null}
-		);
-		expect(result).to.be.true;
+		)).to.not.throw();
 	});
 
 	it('should pass an empty note Immutable.Map', () => {
-		const result = validateSubmissionSection(
+		expect(() => validateSubmissionSection(
 			Immutable.fromJS(EMPTY_SUBMISSION_SECTION)
-		);
-		expect(result).to.be.true;
+		)).to.not.throw();
 	});
 
 	it('should reject any other non-null data type', () => {
-		const result = validateSubmissionSection(
+		expect(() => validateSubmissionSection(
 			{...VALID_SUBMISSION_SECTION, note: 1}
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should pass a null value', () => {
-		const result = validateSubmissionSection(null);
-		expect(result).to.be.true;
+		expect(() => validateSubmissionSection(null)).to.not.throw();
 	});
 }
 

--- a/test/validators/test-submission-section.js
+++ b/test/validators/test-submission-section.js
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2017  Ben Ockmore
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+import * as Immutable from 'immutable';
+
+import {EMPTY_SUBMISSION_SECTION, VALID_SUBMISSION_SECTION} from './data';
+import {
+	validateSubmissionSection,
+	validateSubmissionSectionNote
+} from '../../lib/validators/common';
+
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import {testValidateStringFunc} from './helpers';
+
+
+chai.use(chaiAsPromised);
+const {expect} = chai;
+
+
+function describeValidateSubmissionSectionNote() {
+	testValidateStringFunc(validateSubmissionSectionNote, false);
+}
+
+
+function describeValidateSubmissionSection() {
+	it('should pass a valid Object', () => {
+		const result = validateSubmissionSection(VALID_SUBMISSION_SECTION);
+		expect(result).to.be.true;
+	});
+
+	it('should pass a valid Immutable.Map', () => {
+		const result = validateSubmissionSection(
+			Immutable.fromJS(VALID_SUBMISSION_SECTION)
+		);
+		expect(result).to.be.true;
+	});
+
+	it('should pass an Object with an empty note', () => {
+		const result = validateSubmissionSection(
+			{...VALID_SUBMISSION_SECTION, note: null}
+		);
+		expect(result).to.be.true;
+	});
+
+	it('should pass an empty note Immutable.Map', () => {
+		const result = validateSubmissionSection(
+			Immutable.fromJS(EMPTY_SUBMISSION_SECTION)
+		);
+		expect(result).to.be.true;
+	});
+
+	it('should reject any other non-null data type', () => {
+		const result = validateSubmissionSection(
+			{...VALID_SUBMISSION_SECTION, note: 1}
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should pass a null value', () => {
+		const result = validateSubmissionSection(null);
+		expect(result).to.be.true;
+	});
+}
+
+
+function tests() {
+	describe(
+		'validateSubmissionSectionNote',
+		describeValidateSubmissionSectionNote
+	);
+	describe('validateSubmissionSection', describeValidateSubmissionSection);
+}
+
+describe('validateSubmissionSection* functions', tests);

--- a/test/validators/test-work.js
+++ b/test/validators/test-work.js
@@ -1,0 +1,267 @@
+/*
+ * Copyright (C) 2017  Ben Ockmore
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+import * as Immutable from 'immutable';
+
+import {
+	EMPTY_SUBMISSION_SECTION,
+	IDENTIFIER_TYPES,
+	INVALID_ALIASES,
+	INVALID_IDENTIFIERS,
+	INVALID_NAME_SECTION,
+	VALID_ALIASES,
+	VALID_IDENTIFIERS,
+	VALID_NAME_SECTION,
+	VALID_SUBMISSION_SECTION
+} from './data';
+import {
+	validateForm,
+	validateWorkSection,
+	validateWorkSectionLanguage,
+	validateWorkSectionType
+} from '../../lib/validators/work';
+
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import {testValidatePositiveIntegerFunc} from './helpers';
+
+
+chai.use(chaiAsPromised);
+const {expect} = chai;
+
+
+function describeValidateWorkSectionLanguage() {
+	const validLanguage = {value: 1};
+
+	it('should pass a valid Object', () => {
+		const result = validateWorkSectionLanguage(validLanguage);
+		expect(result).to.be.true;
+	});
+
+	it('should pass a valid Immutable.Map', () => {
+		const result = validateWorkSectionLanguage(
+			Immutable.fromJS(validLanguage)
+		);
+		expect(result).to.be.true;
+	});
+
+	it('should reject an Object with an invalid value', () => {
+		const result = validateWorkSectionLanguage(
+			{...validLanguage, value: 'bad'}
+		);
+		expect(result).to.be.false;
+	});
+
+	const invalidLanguage = {value: 'bad'};
+
+	it('should reject an invalid Immutable.Map', () => {
+		const result = validateWorkSectionLanguage(
+			Immutable.fromJS(invalidLanguage)
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should reject any other non-null data type', () => {
+		const result = validateWorkSectionLanguage(1);
+		expect(result).to.be.false;
+	});
+
+	it('should pass a null value', () => {
+		const result = validateWorkSectionLanguage(null);
+		expect(result).to.be.true;
+	});
+}
+
+function describeValidateWorkSectionType() {
+	testValidatePositiveIntegerFunc(validateWorkSectionType, false);
+}
+
+const VALID_WORK_SECTION = {
+	language: {value: 1},
+	type: 1
+};
+const INVALID_WORK_SECTION = {...VALID_WORK_SECTION, type: {}};
+
+function describeValidateWorkSection() {
+	it('should pass a valid Object', () => {
+		const result = validateWorkSection(VALID_WORK_SECTION);
+		expect(result).to.be.true;
+	});
+
+	it('should pass a valid Immutable.Map', () => {
+		const result = validateWorkSection(
+			Immutable.fromJS(VALID_WORK_SECTION)
+		);
+		expect(result).to.be.true;
+	});
+
+	it('should reject an Object with an invalid language', () => {
+		const result = validateWorkSection({
+			...VALID_WORK_SECTION,
+			language: {value: 'bad'}
+		});
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid type', () => {
+		const result = validateWorkSection({
+			...VALID_WORK_SECTION,
+			type: {}
+		});
+		expect(result).to.be.false;
+	});
+
+	it('should reject an invalid Immutable.Map', () => {
+		const result = validateWorkSection(
+			Immutable.fromJS(INVALID_WORK_SECTION)
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should pass any other non-null data type', () => {
+		const result = validateWorkSection(1);
+		expect(result).to.be.true;
+	});
+
+	it('should pass a null value', () => {
+		const result = validateWorkSection(null);
+		expect(result).to.be.true;
+	});
+}
+
+function describeValidateForm() {
+	const validForm = {
+		aliasEditor: VALID_ALIASES,
+		identifierEditor: VALID_IDENTIFIERS,
+		nameSection: VALID_NAME_SECTION,
+		submissionSection: VALID_SUBMISSION_SECTION,
+		workSection: VALID_WORK_SECTION
+	};
+
+	it('should pass a valid Object', () => {
+		const result = validateForm(validForm, IDENTIFIER_TYPES);
+		expect(result).to.be.true;
+	});
+
+	it('should pass a valid Immutable.Map', () => {
+		const result = validateForm(
+			Immutable.fromJS(validForm),
+			IDENTIFIER_TYPES
+		);
+		expect(result).to.be.true;
+	});
+
+	it('should reject an Object with an invalid alias editor', () => {
+		const result = validateForm(
+			{
+				...validForm,
+				aliasEditor: INVALID_ALIASES
+			},
+			IDENTIFIER_TYPES
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid identifier editor', () => {
+		const result = validateForm(
+			{
+				...validForm,
+				identifierEditor: INVALID_IDENTIFIERS
+			}, IDENTIFIER_TYPES
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid name section', () => {
+		const result = validateForm(
+			{
+				...validForm,
+				nameSection: INVALID_NAME_SECTION
+			},
+			IDENTIFIER_TYPES
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should reject an Object with an invalid work section', () => {
+		const result = validateForm(
+			{
+				...validForm,
+				workSection: INVALID_WORK_SECTION
+			},
+			IDENTIFIER_TYPES
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should pass an Object with an empty submission section', () => {
+		const result = validateForm(
+			{
+				...validForm,
+				submissionSection: EMPTY_SUBMISSION_SECTION
+			},
+			IDENTIFIER_TYPES
+		);
+		expect(result).to.be.true;
+	});
+
+	const invalidForm = {
+		...validForm,
+		nameSection: INVALID_NAME_SECTION
+	};
+
+	it('should reject an invalid Immutable.Map', () => {
+		const result = validateForm(
+			Immutable.fromJS(invalidForm),
+			IDENTIFIER_TYPES
+		);
+		expect(result).to.be.false;
+	});
+
+	it('should reject any other non-null data type', () => {
+		const result = validateForm(1, IDENTIFIER_TYPES);
+		expect(result).to.be.false;
+	});
+
+	it('should reject a null value', () => {
+		const result = validateForm(null, IDENTIFIER_TYPES);
+		expect(result).to.be.false;
+	});
+}
+
+
+function tests() {
+	describe(
+		'validateWorkSectionLanguage',
+		describeValidateWorkSectionLanguage
+	);
+	describe(
+		'validateWorkSectionType',
+		describeValidateWorkSectionType
+	);
+	describe(
+		'validateWorkSection',
+		describeValidateWorkSection
+	);
+	describe(
+		'validateForm',
+		describeValidateForm
+	);
+}
+
+describe('validateWorkSection* functions', tests);

--- a/test/validators/test-work.js
+++ b/test/validators/test-work.js
@@ -30,7 +30,7 @@ import {
 	VALID_SUBMISSION_SECTION
 } from './data';
 import {
-	validateForm,
+	validateWork,
 	validateWorkSection,
 	validateWorkSectionLanguage,
 	validateWorkSectionType
@@ -142,18 +142,18 @@ function describeValidateForm() {
 	};
 
 	it('should pass a valid Object', () => {
-		expect(() => validateForm(validForm, IDENTIFIER_TYPES)).to.not.throw();
+		expect(() => validateWork(validForm, IDENTIFIER_TYPES)).to.not.throw();
 	});
 
 	it('should pass a valid Immutable.Map', () => {
-		expect(() => validateForm(
+		expect(() => validateWork(
 			Immutable.fromJS(validForm),
 			IDENTIFIER_TYPES
 		)).to.not.throw();
 	});
 
 	it('should reject an Object with an invalid alias editor', () => {
-		expect(() => validateForm(
+		expect(() => validateWork(
 			{
 				...validForm,
 				aliasEditor: INVALID_ALIASES
@@ -163,7 +163,7 @@ function describeValidateForm() {
 	});
 
 	it('should reject an Object with an invalid identifier editor', () => {
-		expect(() => validateForm(
+		expect(() => validateWork(
 			{
 				...validForm,
 				identifierEditor: INVALID_IDENTIFIERS
@@ -172,7 +172,7 @@ function describeValidateForm() {
 	});
 
 	it('should reject an Object with an invalid name section', () => {
-		expect(() => validateForm(
+		expect(() => validateWork(
 			{
 				...validForm,
 				nameSection: INVALID_NAME_SECTION
@@ -182,7 +182,7 @@ function describeValidateForm() {
 	});
 
 	it('should reject an Object with an invalid work section', () => {
-		expect(() => validateForm(
+		expect(() => validateWork(
 			{
 				...validForm,
 				workSection: INVALID_WORK_SECTION
@@ -192,7 +192,7 @@ function describeValidateForm() {
 	});
 
 	it('should pass an Object with an empty submission section', () => {
-		expect(() => validateForm(
+		expect(() => validateWork(
 			{
 				...validForm,
 				submissionSection: EMPTY_SUBMISSION_SECTION
@@ -207,18 +207,18 @@ function describeValidateForm() {
 	};
 
 	it('should reject an invalid Immutable.Map', () => {
-		expect(() => validateForm(
+		expect(() => validateWork(
 			Immutable.fromJS(invalidForm),
 			IDENTIFIER_TYPES
 		)).to.throw(ValidationError);
 	});
 
 	it('should reject any other non-null data type', () => {
-		expect(() => validateForm(1, IDENTIFIER_TYPES)).to.throw(ValidationError);
+		expect(() => validateWork(1, IDENTIFIER_TYPES)).to.throw(ValidationError);
 	});
 
 	it('should reject a null value', () => {
-		expect(() => validateForm(null, IDENTIFIER_TYPES)).to.throw(ValidationError);
+		expect(() => validateWork(null, IDENTIFIER_TYPES)).to.throw(ValidationError);
 	});
 }
 

--- a/test/validators/test-work.js
+++ b/test/validators/test-work.js
@@ -36,6 +36,7 @@ import {
 	validateWorkSectionType
 } from '../../lib/validators/work';
 
+import {ValidationError} from '../../lib/validators/base';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import {testValidatePositiveIntegerFunc} from './helpers';
@@ -49,41 +50,35 @@ function describeValidateWorkSectionLanguage() {
 	const validLanguage = {value: 1};
 
 	it('should pass a valid Object', () => {
-		const result = validateWorkSectionLanguage(validLanguage);
-		expect(result).to.be.true;
+		expect(() => validateWorkSectionLanguage(validLanguage)).to.not.throw();
 	});
 
 	it('should pass a valid Immutable.Map', () => {
-		const result = validateWorkSectionLanguage(
+		expect(() => validateWorkSectionLanguage(
 			Immutable.fromJS(validLanguage)
-		);
-		expect(result).to.be.true;
+		)).to.not.throw();
 	});
 
 	it('should reject an Object with an invalid value', () => {
-		const result = validateWorkSectionLanguage(
+		expect(() => validateWorkSectionLanguage(
 			{...validLanguage, value: 'bad'}
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	const invalidLanguage = {value: 'bad'};
 
 	it('should reject an invalid Immutable.Map', () => {
-		const result = validateWorkSectionLanguage(
+		expect(() => validateWorkSectionLanguage(
 			Immutable.fromJS(invalidLanguage)
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should reject any other non-null data type', () => {
-		const result = validateWorkSectionLanguage(1);
-		expect(result).to.be.false;
+		expect(() => validateWorkSectionLanguage(1)).to.throw(ValidationError);
 	});
 
 	it('should pass a null value', () => {
-		const result = validateWorkSectionLanguage(null);
-		expect(result).to.be.true;
+		expect(() => validateWorkSectionLanguage(null)).to.not.throw();
 	});
 }
 
@@ -99,48 +94,41 @@ const INVALID_WORK_SECTION = {...VALID_WORK_SECTION, type: {}};
 
 function describeValidateWorkSection() {
 	it('should pass a valid Object', () => {
-		const result = validateWorkSection(VALID_WORK_SECTION);
-		expect(result).to.be.true;
+		expect(() => validateWorkSection(VALID_WORK_SECTION)).to.not.throw();
 	});
 
 	it('should pass a valid Immutable.Map', () => {
-		const result = validateWorkSection(
+		expect(() => validateWorkSection(
 			Immutable.fromJS(VALID_WORK_SECTION)
-		);
-		expect(result).to.be.true;
+		)).to.not.throw();
 	});
 
 	it('should reject an Object with an invalid language', () => {
-		const result = validateWorkSection({
+		expect(() => validateWorkSection({
 			...VALID_WORK_SECTION,
 			language: {value: 'bad'}
-		});
-		expect(result).to.be.false;
+		})).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid type', () => {
-		const result = validateWorkSection({
+		expect(() => validateWorkSection({
 			...VALID_WORK_SECTION,
 			type: {}
-		});
-		expect(result).to.be.false;
+		})).to.throw(ValidationError);
 	});
 
 	it('should reject an invalid Immutable.Map', () => {
-		const result = validateWorkSection(
+		expect(() => validateWorkSection(
 			Immutable.fromJS(INVALID_WORK_SECTION)
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should pass any other non-null data type', () => {
-		const result = validateWorkSection(1);
-		expect(result).to.be.true;
+		expect(() => validateWorkSection(1)).to.not.throw();
 	});
 
 	it('should pass a null value', () => {
-		const result = validateWorkSection(null);
-		expect(result).to.be.true;
+		expect(() => validateWorkSection(null)).to.not.throw();
 	});
 }
 
@@ -154,70 +142,63 @@ function describeValidateForm() {
 	};
 
 	it('should pass a valid Object', () => {
-		const result = validateForm(validForm, IDENTIFIER_TYPES);
-		expect(result).to.be.true;
+		expect(() => validateForm(validForm, IDENTIFIER_TYPES)).to.not.throw();
 	});
 
 	it('should pass a valid Immutable.Map', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			Immutable.fromJS(validForm),
 			IDENTIFIER_TYPES
-		);
-		expect(result).to.be.true;
+		)).to.not.throw();
 	});
 
 	it('should reject an Object with an invalid alias editor', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			{
 				...validForm,
 				aliasEditor: INVALID_ALIASES
 			},
 			IDENTIFIER_TYPES
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid identifier editor', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			{
 				...validForm,
 				identifierEditor: INVALID_IDENTIFIERS
 			}, IDENTIFIER_TYPES
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid name section', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			{
 				...validForm,
 				nameSection: INVALID_NAME_SECTION
 			},
 			IDENTIFIER_TYPES
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should reject an Object with an invalid work section', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			{
 				...validForm,
 				workSection: INVALID_WORK_SECTION
 			},
 			IDENTIFIER_TYPES
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should pass an Object with an empty submission section', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			{
 				...validForm,
 				submissionSection: EMPTY_SUBMISSION_SECTION
 			},
 			IDENTIFIER_TYPES
-		);
-		expect(result).to.be.true;
+		)).to.not.throw();
 	});
 
 	const invalidForm = {
@@ -226,21 +207,18 @@ function describeValidateForm() {
 	};
 
 	it('should reject an invalid Immutable.Map', () => {
-		const result = validateForm(
+		expect(() => validateForm(
 			Immutable.fromJS(invalidForm),
 			IDENTIFIER_TYPES
-		);
-		expect(result).to.be.false;
+		)).to.throw(ValidationError);
 	});
 
 	it('should reject any other non-null data type', () => {
-		const result = validateForm(1, IDENTIFIER_TYPES);
-		expect(result).to.be.false;
+		expect(() => validateForm(1, IDENTIFIER_TYPES)).to.throw(ValidationError);
 	});
 
 	it('should reject a null value', () => {
-		const result = validateForm(null, IDENTIFIER_TYPES);
-		expect(result).to.be.false;
+		expect(() => validateForm(null, IDENTIFIER_TYPES)).to.throw(ValidationError);
 	});
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3982,6 +3982,11 @@ util@^0.10.3:
   dependencies:
     inherits "2.0.3"
 
+validator@^13.7.0:
+  version "13.12.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-13.12.0.tgz#7d78e76ba85504da3fee4fd1922b385914d4b35f"
+  integrity sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==
+
 which-boxed-primitive@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz#13757bc89b209b049fe5d86430e21cf40a89a8e6"


### PR DESCRIPTION
### Problem

We have two nearly duplicate sets of entity validation functions in [`bookbrainz-site`](https://github.com/metabrainz/bookbrainz-site/tree/2315cb7707a31dc096758c03d7df128f15588d1e/src/client/entity-editor/validators) and [`bookbrainz-utils`](https://github.com/metabrainz/bookbrainz-utils/tree/421cbc9e9783ca5e957b6291efa378e2a3519bd8/importer/src/consumer/validators) which should ideally be part of `bookbrainz-data` and then can be used by both.

### Solution

- Copy the validators and their tests from `bookbrainz-site` into this repository and make sure the tests still pass (`yarn build-js-for-test && mocha test/validators`).
- Refactor validators to throw a `ValidationError` with the reason instead of just a boolean.
- Adapt tests to expect errors. (Luckily this was mostly a search and replace job with the proper regular expressions.)
- Copy type definitions for the validated entity sections from  `bookbrainz-utils`.
- Integrate specific differences of the validators from `bookbrainz-utils`. Apart from the thrown error messages, which can be used for logging, and a few outdated/wrong checks this would be a912ab96bd25588399d2cd5a88604357c1c1d2de only!

Changes are probably best reviewed commit by commit.

### Areas of Impact

None so far, the unified validators will only be used in the other two repos.

### Remaining Tasks

- [x] Mute the stupid "Function 'dateValidator' has a complexity of 24. Maximum allowed is 20  complexity" error? This was no problem [in `bookbrainz-site` where a complexity of 50 is allowed](https://github.com/metabrainz/bookbrainz-site/blob/2315cb7707a31dc096758c03d7df128f15588d1e/.eslintrc.js#L65).
- [ ] Change our expectations for some validators, they don't make much sense (see my TODO code comments)
- [ ] There are also some [inconsistent property names](https://github.com/metabrainz/bookbrainz-utils/commit/a293b703667282130db2318c336c004e7c7f5fc4) like `language` which is the ID in forms and for the validators while it is the lazy-loaded object for `languageId` elsewhere. We could change these in `bookbrainz-site` to make the code and the types cleaner.
- [x] Use validators for the import consumer in `bookbrainz-utils` (https://github.com/metabrainz/bookbrainz-utils/pull/46)
- [ ] Use validators in `bookbrainz-site` (should be even more straightforward than for `bookbrainz-utils`)
- [x] Delete validators in `bookbrainz-utils`
- [ ] Delete validators in `bookbrainz-site`
- [ ] Delete utils in `bookbrainz-site` which had to be copied over into `bookbrainz-data` or are otherwise unused (I have a list which I will share)
