### PR TITLE
Fix type of author credit size in validators

### DIFF
--- a/src/validators/edition-group.ts
+++ b/src/validators/edition-group.ts
@@ -29,6 +29,7 @@ import {
 } from './common';
 
 import type {IdentifierTypeWithIdT} from '../types/identifiers';
+import {Iterable} from 'immutable';
 import _ from 'lodash';
 import {isIterable} from '../util';
 
@@ -52,8 +53,13 @@ export function validateEditionGroup(
 		validateAuthorCreditSectionMerge(get(formData, 'authorCredit', {}));
 	}
 	else if (!authorCreditEnable) {
-		const emptyAuthorCredit = isIterable(formData) ? formData.get('authorCreditEditor')?.size === 0 :
-			_.size(get(formData, 'authorCreditEditor', {})) === 0;
+		let emptyAuthorCredit:boolean;
+		if (isIterable(formData)) {
+			emptyAuthorCredit = (formData.get('authorCreditEditor') as Iterable<unknown, unknown>)?.size === 0;
+		}
+		else {
+			emptyAuthorCredit = _.size(get(formData, 'authorCreditEditor', {})) === 0;
+		}
 		if (!emptyAuthorCredit) {
 			throw new ValidationError('Disabled author credit has to be empty', 'authorCreditEditor');
 		}

--- a/src/validators/edition.ts
+++ b/src/validators/edition.ts
@@ -33,6 +33,7 @@ import {ValidationError, get, validateDate, validatePositiveInteger, validateUUI
 import {convertMapToObject, isIterable} from '../util';
 
 import {IdentifierTypeWithIdT} from '../types/identifiers';
+import {Iterable} from 'immutable';
 import _ from 'lodash';
 
 
@@ -127,8 +128,13 @@ export function validateEdition(
 		validateAuthorCreditSectionMerge(get(formData, 'authorCredit', {}));
 	}
 	else if (!authorCreditEnable) {
-		const emptyAuthorCredit = isIterable(formData) ? formData.get('authorCreditEditor')?.size === 0 :
-			_.size(get(formData, 'authorCreditEditor', {})) === 0;
+		let emptyAuthorCredit:boolean;
+		if (isIterable(formData)) {
+			emptyAuthorCredit = (formData.get('authorCreditEditor') as Iterable<unknown, unknown>)?.size === 0;
+		}
+		else {
+			emptyAuthorCredit = _.size(get(formData, 'authorCreditEditor', {})) === 0;
+		}
 		if (!emptyAuthorCredit) {
 			throw new ValidationError('Disabled author credit has to be empty', 'authorCreditEditor');
 		}


### PR DESCRIPTION
Following from #316 we saw a failing build caused by a type issue with the author credit section Immutable Iterable type, specifically its size property

I will note that the Immutable types have this to say about `size`:
![image](https://github.com/metabrainz/bookbrainz-data-js/assets/6179856/3f7db4c1-e61e-4d12-823a-6d5f326811d2)
