### PR TITLE
Make approval of imported entities work

### DIFF
--- a/src/func/create-entity.ts
+++ b/src/func/create-entity.ts
@@ -148,5 +148,5 @@ export async function createEntity({
 		withRelated: ['defaultAlias']
 	});
 
-	return entity.toJSON();
+	return entity;
 }

--- a/src/func/create-entity.ts
+++ b/src/func/create-entity.ts
@@ -58,11 +58,11 @@ interface CreateEntityPropsType {
 	entityType: EntityTypeString
 }
 
-// TODO: function seems to be unused across all BB repos, ignore its errors (and delete it?)
+// TODO: function is only used to approve imports, check whether type error below is critical
 export async function createEntity({
 	editorId, entityData, orm, transacting
 }: CreateEntityPropsType) {
-	const {Revision} = orm;
+	const {Entity, Revision} = orm;
 
 	const {aliases, annotation, disambiguation, identifiers, note,
 		type: entityType, ...entitySetData} = entityData;
@@ -105,7 +105,7 @@ export async function createEntity({
 	);
 
 	// Get additional props
-	// @ts-expect-error Not sure why we have this error but this whole function is unused across our repos
+	// @ts-expect-error Not sure why we have this error
 	const additionalProps = getAdditionalEntityProps(entityData, entityType);
 
 	// Create entitySets
@@ -123,9 +123,12 @@ export async function createEntity({
 		editorUpdatePromise, notePromise
 	]);
 
+	const newEntity = await new Entity({type: entityType})
+		.save(null, {transacting});
 	const propsToSet = _.extend({
 		aliasSetId: aliasSetRecord && aliasSetRecord.get('id'),
 		annotationId: annotationRecord && annotationRecord.get('id'),
+		bbid: newEntity.get('bbid'),
 		disambiguationId:
 			disambiguationRecord && disambiguationRecord.get('id'),
 		identifierSetId: identSetRecord && identSetRecord.get('id'),

--- a/src/func/imports/approve-import.ts
+++ b/src/func/imports/approve-import.ts
@@ -41,7 +41,7 @@ export async function approveImport(
 		identifierSetId} = importEntity;
 	const {id: aliasSetId} = aliasSet;
 
-	const {Revision} = orm;
+	const {Entity, Revision} = orm;
 
 	// Increase user edit count
 	const editorUpdatePromise =
@@ -74,8 +74,11 @@ export async function approveImport(
 		revisionPromise, notePromise, editorUpdatePromise
 	]);
 
+	const newEntity = await new Entity({type: entityType})
+		.save(null, {transacting});
 	const propsToSet = _.extend({
 		aliasSetId,
+		bbid: newEntity.get('bbid'),
 		disambiguationId,
 		identifierSetId,
 		revisionId: revisionRecord && revisionRecord.get('id')

--- a/src/func/imports/approve-import.ts
+++ b/src/func/imports/approve-import.ts
@@ -76,9 +76,10 @@ export async function approveImport(
 
 	const newEntity = await new Entity({type: entityType})
 		.save(null, {transacting});
+	const bbid = newEntity.get('bbid');
 	const propsToSet = _.extend({
 		aliasSetId,
-		bbid: newEntity.get('bbid'),
+		bbid,
 		disambiguationId,
 		identifierSetId,
 		revisionId: revisionRecord && revisionRecord.get('id')
@@ -95,9 +96,9 @@ export async function approveImport(
 	const entity = await entityModel.refresh({
 		transacting,
 		withRelated: ['defaultAlias']
-	}).then(entityObject => entityObject.toJSON());
+	});
 
-	await deleteImport(transacting, importId, entity.bbid);
+	await deleteImport(transacting, importId, bbid);
 
 	return entity;
 }


### PR DESCRIPTION
### Problem

Approving imported entities currently fails on https://github.com/metabrainz/bookbrainz-site/commit/66845752f6a5b09bdc13bb8b3cb582ef139b03e4

### Solution

- Avoid SQL errors for direct approval (`approveImport`) and the edit and approve workflow (`createEntity`)
- Return the full Bookshelf model which is needed for search indexing in https://github.com/metabrainz/bookbrainz-site/pull/1103

### Areas of Impact

Only import related ORM functions are affected this time.
Doing an npm an release is not required yet, there will be more changes soon and I am using a local version of the ORM package anyway.