### PR TITLE
Support annotations for imported entities

### DIFF
--- a/src/func/annotation.ts
+++ b/src/func/annotation.ts
@@ -45,7 +45,7 @@ export function updateAnnotation(
 	if (newContent) {
 		return new Annotation({
 			content: newContent,
-			lastRevisionId: revision.get('id')
+			lastRevisionId: revision && revision.get('id')
 		}).save(null, {transacting});
 	}
 	return Promise.resolve(null);

--- a/src/func/imports/create-import.ts
+++ b/src/func/imports/create-import.ts
@@ -29,6 +29,7 @@ import {camelToSnake} from '../../util';
 import {getAdditionalEntityProps} from '../entity';
 import {getOriginSourceId} from './misc';
 import {updateAliasSet} from '../alias';
+import {updateAnnotation} from '../annotation';
 import {updateDisambiguation} from '../disambiguation';
 import {updateIdentifierSet} from '../identifier';
 import {updateLanguageSet} from '../language';
@@ -60,6 +61,7 @@ type ExtraDataSetIds = Partial<{
 /** IDs of all data sets which an entity can have. */
 type DataSetIds = {
 	aliasSetId: number;
+	annotationId: number;
 	disambiguationId: number;
 	identifierSetId: number;
 } & ExtraDataSetIds;
@@ -154,7 +156,7 @@ export function createImport(orm: ORM, importData: QueuedEntity, {
 
 	return orm.bookshelf.transaction<ImportResult>(async (transacting) => {
 		const {entityType} = importData;
-		const {alias, identifiers, disambiguation, source} = importData.data;
+		const {alias, annotation, identifiers, disambiguation, source} = importData.data;
 
 		// Get origin_source
 		let originSourceId: number = null;
@@ -197,9 +199,10 @@ export function createImport(orm: ORM, importData: QueuedEntity, {
 			}
 		}
 
-		const [aliasSet, identifierSet, disambiguationObj, entityExtraDataSets] =
+		const [aliasSet, annotationObj, identifierSet, disambiguationObj, entityExtraDataSets] =
 			await Promise.all([
 				updateAliasSet(orm, transacting, null, null, alias),
+				updateAnnotation(orm, transacting, null, annotation, null),
 				updateIdentifierSet(orm, transacting, null, identifiers),
 				updateDisambiguation(orm, transacting, null, disambiguation),
 				updateEntityExtraDataSets(orm, transacting, importData.data)
@@ -212,6 +215,7 @@ export function createImport(orm: ORM, importData: QueuedEntity, {
 				transacting,
 				{
 					aliasSetId: aliasSet && aliasSet.get('id'),
+					annotationId: annotationObj && annotationObj.get('id'),
 					disambiguationId: disambiguationObj && disambiguationObj.get('id'),
 					identifierSetId: identifierSet && identifierSet.get('id'),
 					...entityExtraDataSets

--- a/src/types/parser.ts
+++ b/src/types/parser.ts
@@ -96,8 +96,8 @@ export type ParsedEntity =
 	| ParsedWork;
 
 // TODO: drop redundant properties which are present in `data` and at the top level
-export type QueuedEntity = {
-	data: ParsedEntity;
+export type QueuedEntity<T extends ParsedEntity = ParsedEntity> = {
+	data: T;
 	entityType: EntityTypeString;
 	source: string;
 	lastEdited?: string;

--- a/src/validators/author.ts
+++ b/src/validators/author.ts
@@ -21,6 +21,7 @@
 import {
 	type AreaStub,
 	validateAliases,
+	validateAnnotationSection,
 	validateIdentifiers,
 	validateNameSection,
 	validateSubmissionSection
@@ -103,6 +104,7 @@ export function validateAuthor(
 	validateIdentifiers(get(formData, 'identifierEditor', {}), identifierTypes);
 	validateNameSection(get(formData, 'nameSection', {}));
 	validateAuthorSection(get(formData, 'authorSection', {}));
+	validateAnnotationSection(get(formData, 'annotationSection', {}));
 	validateSubmissionSection(get(formData, 'submissionSection', {}));
 }
 

--- a/src/validators/common.ts
+++ b/src/validators/common.ts
@@ -163,6 +163,14 @@ export function validateNameSection(
 	validateNameSectionDisambiguation(get(values, 'disambiguation', null));
 }
 
+export function validateAnnotationSectionContent(value: any): void {
+	validateOptionalString(value, 'annotationSection.content');
+}
+
+export function validateAnnotationSection(data: any): void {
+	validateAnnotationSectionContent(get(data, 'content', null));
+}
+
 export function validateSubmissionSectionNote(value: any): void {
 	validateOptionalString(value, 'submissionSection.note');
 }
@@ -213,6 +221,10 @@ export type AliasSection = Record<string, AliasWithDefaultT & {
 export type IdentifierSection = Record<string, IdentifierT & {
 	type: number;
 }>;
+
+export type AnnotationSection = {
+	content?: string;
+};
 
 export type SubmissionSection = {
 	note?: string;

--- a/src/validators/common.ts
+++ b/src/validators/common.ts
@@ -175,15 +175,10 @@ export function validateSubmissionSectionNote(value: any): void {
 	validateOptionalString(value, 'submissionSection.note');
 }
 
-export function validateSubmissionSectionAnnotation(value: any): void {
-	validateOptionalString(value, 'submissionSection.annotation.content');
-}
-
 export function validateSubmissionSection(
 	data: any
 ): void {
 	validateSubmissionSectionNote(get(data, 'note', null));
-	validateSubmissionSectionAnnotation(get(data, 'annotation.content', null));
 }
 
 export function validateAuthorCreditRow(row: any): void {
@@ -228,9 +223,6 @@ export type AnnotationSection = {
 
 export type SubmissionSection = {
 	note?: string;
-	annotation?: {
-		content: string;
-	};
 };
 
 export type AuthorCreditRow = {

--- a/src/validators/common.ts
+++ b/src/validators/common.ts
@@ -214,6 +214,13 @@ export type IdentifierSection = Record<string, IdentifierT & {
 	type: number;
 }>;
 
+export type SubmissionSection = {
+	note?: string;
+	annotation?: {
+		content: string;
+	};
+};
+
 export type AuthorCreditRow = {
 	author: EntityStub;
 	joinPhrase?: string;

--- a/src/validators/edition-group.ts
+++ b/src/validators/edition-group.ts
@@ -21,6 +21,7 @@
 import {ValidationError, get, validatePositiveInteger} from './base';
 import {
 	validateAliases,
+	validateAnnotationSection,
 	validateAuthorCreditSection,
 	validateAuthorCreditSectionMerge,
 	validateIdentifiers,
@@ -72,6 +73,7 @@ export function validateEditionGroup(
 	validateIdentifiers(get(formData, 'identifierEditor', {}), identifierTypes);
 	validateNameSection(get(formData, 'nameSection', {}));
 	validateEditionGroupSection(get(formData, 'editionGroupSection', {}));
+	validateAnnotationSection(get(formData, 'annotationSection', {}));
 	validateSubmissionSection(get(formData, 'submissionSection', {}));
 }
 

--- a/src/validators/edition.ts
+++ b/src/validators/edition.ts
@@ -22,6 +22,7 @@ import {
 	type EntityStub,
 	type LanguageStub,
 	validateAliases,
+	validateAnnotationSection,
 	validateAuthorCreditSection,
 	validateAuthorCreditSectionMerge,
 	validateIdentifiers,
@@ -147,6 +148,7 @@ export function validateEdition(
 	validateIdentifiers(get(formData, 'identifierEditor', {}), identifierTypes);
 	validateNameSection(get(formData, 'nameSection', {}));
 	validateEditionSection(get(formData, 'editionSection', {}));
+	validateAnnotationSection(get(formData, 'annotationSection', {}));
 	validateSubmissionSection(get(formData, 'submissionSection', {}));
 }
 

--- a/src/validators/publisher.ts
+++ b/src/validators/publisher.ts
@@ -19,7 +19,10 @@
 
 import {
 	type AreaStub,
-	validateAliases, validateIdentifiers, validateNameSection,
+	validateAliases,
+	validateAnnotationSection,
+	validateIdentifiers,
+	validateNameSection,
 	validateSubmissionSection
 } from './common';
 import {ValidationError, dateIsBefore, get, validateDate, validatePositiveInteger} from './base';
@@ -86,6 +89,7 @@ export function validatePublisher(
 	validateIdentifiers(get(formData, 'identifierEditor', {}), identifierTypes);
 	validateNameSection(get(formData, 'nameSection', {}));
 	validatePublisherSection(get(formData, 'publisherSection', {}));
+	validateAnnotationSection(get(formData, 'annotationSection', {}));
 	validateSubmissionSection(get(formData, 'submissionSection', {}));
 }
 

--- a/src/validators/series.ts
+++ b/src/validators/series.ts
@@ -22,6 +22,7 @@
 import {ValidationError, get, validatePositiveInteger} from './base';
 import {
 	validateAliases,
+	validateAnnotationSection,
 	validateIdentifiers,
 	validateNameSection,
 	validateSubmissionSection
@@ -58,6 +59,7 @@ export function validateSeries(
 	validateIdentifiers(get(formData, 'identifierEditor', {}), identifierTypes);
 	validateNameSection(get(formData, 'nameSection', {}));
 	validateSeriesSection(get(formData, 'seriesSection', {}));
+	validateAnnotationSection(get(formData, 'annotationSection', {}));
 	validateSubmissionSection(get(formData, 'submissionSection', {}));
 }
 

--- a/src/validators/work.ts
+++ b/src/validators/work.ts
@@ -20,7 +20,7 @@
 
 import {
 	LanguageStub,
-	validateAliases, validateIdentifiers, validateNameSection,
+	validateAliases, validateAnnotationSection, validateIdentifiers, validateNameSection,
 	validateSubmissionSection
 } from './common';
 import {get, validatePositiveInteger} from './base';
@@ -51,6 +51,7 @@ export function validateWork(
 	validateIdentifiers(get(formData, 'identifierEditor', {}), identifierTypes);
 	validateNameSection(get(formData, 'nameSection', {}));
 	validateWorkSection(get(formData, 'workSection', {}));
+	validateAnnotationSection(get(formData, 'annotationSection', {}));
 	validateSubmissionSection(get(formData, 'submissionSection', {}));
 }
 

--- a/test/validators/data.js
+++ b/test/validators/data.js
@@ -88,6 +88,14 @@ export const VALID_NAME_SECTION = {
 
 export const INVALID_NAME_SECTION = {...VALID_NAME_SECTION, language: null};
 
+export const VALID_ANNOTATION_SECTION = {
+	content: 'blah blah'
+};
+
+export const EMPTY_ANNOTATION_SECTION = {
+	content: null
+};
+
 export const VALID_SUBMISSION_SECTION = {
 	note: 'blah'
 };

--- a/test/validators/test-annotation-section.js
+++ b/test/validators/test-annotation-section.js
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2024  David Kellner
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+import * as Immutable from 'immutable';
+
+import {EMPTY_ANNOTATION_SECTION, VALID_ANNOTATION_SECTION} from './data';
+import {
+	validateAnnotationSection,
+	validateAnnotationSectionContent
+} from '../../lib/validators/common';
+
+import {ValidationError} from '../../lib/validators/base';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import {testValidateStringFunc} from './helpers';
+
+
+chai.use(chaiAsPromised);
+const {expect} = chai;
+
+
+function describeValidateAnnotationSectionContent() {
+	testValidateStringFunc(validateAnnotationSectionContent, false);
+}
+
+
+function describeValidateAnnotationSection() {
+	it('should pass a valid Object', () => {
+		expect(() => validateAnnotationSection(VALID_ANNOTATION_SECTION)).to.not.throw();
+	});
+
+	it('should pass a valid Immutable.Map', () => {
+		expect(() => validateAnnotationSection(
+			Immutable.fromJS(VALID_ANNOTATION_SECTION)
+		)).to.not.throw();
+	});
+
+	it('should pass an Object with an empty content', () => {
+		expect(() => validateAnnotationSection(
+			{...VALID_ANNOTATION_SECTION, content: null}
+		)).to.not.throw();
+	});
+
+	it('should pass an empty content Immutable.Map', () => {
+		expect(() => validateAnnotationSection(
+			Immutable.fromJS(EMPTY_ANNOTATION_SECTION)
+		)).to.not.throw();
+	});
+
+	it('should reject any other non-null data type', () => {
+		expect(() => validateAnnotationSection(
+			{...VALID_ANNOTATION_SECTION, content: 1}
+		)).to.throw(ValidationError);
+	});
+
+	it('should pass a null value', () => {
+		expect(() => validateAnnotationSection(null)).to.not.throw();
+	});
+}
+
+
+function tests() {
+	describe(
+		'validateAnnotationSectionContent',
+		describeValidateAnnotationSectionContent
+	);
+	describe('validateAnnotationSection', describeValidateAnnotationSection);
+}
+
+describe('validateAnnotationSection* functions', tests);


### PR DESCRIPTION
### Problem

Annotations are not implemented for imported entities, because they have a `last_revision_id INT NOT NULL` column. Since an import does not have a revision, it is not possible to create a valid annotation row for it.

### Solution

Actually use the given annotation data from the queued entity and insert it into the database with `last_revision_id = NULL`.
Before this code is usable, we have to make `annotation.last_revision_id` nullable in the schema and
in the code of `bookbrainz-site`.

P.S. Also sneaking in a minor DX QoL change with a032186.